### PR TITLE
Asset canister upgrade

### DIFF
--- a/CONTEXT.txt
+++ b/CONTEXT.txt
@@ -1,0 +1,644 @@
+// src/core/state/raw_storage/state.rs
+use std::cell::RefCell;
+use std::collections::HashMap;
+use crate::core::state::raw_storage::types::{ChunkId, FileChunk};
+
+thread_local! {
+    pub static CHUNKS: RefCell<HashMap<ChunkId, FileChunk>> = RefCell::new(HashMap::new());
+    pub static FILE_CHUNKS: RefCell<HashMap<String, Vec<ChunkId>>> = RefCell::new(HashMap::new());
+    pub static FILE_META: RefCell<HashMap<String, String>> = RefCell::new(HashMap::new());
+}
+
+pub fn store_chunk(chunk: FileChunk) {
+    CHUNKS.with(|chunks| {
+        chunks.borrow_mut().insert(chunk.id.clone(), chunk.clone());
+    });
+
+    FILE_CHUNKS.with(|file_chunks| {
+        let mut map = file_chunks.borrow_mut();
+        map.entry(chunk.file_id.clone())
+           .or_insert_with(Vec::new)
+           .push(chunk.id);
+    });
+}
+
+pub fn get_chunk(chunk_id: &ChunkId) -> Option<FileChunk> {
+    CHUNKS.with(|chunks| chunks.borrow().get(chunk_id).cloned())
+}
+
+pub fn get_file_chunks(file_id: &str) -> Vec<FileChunk> {
+    FILE_CHUNKS.with(|file_chunks| {
+        if let Some(chunk_ids) = file_chunks.borrow().get(file_id) {
+            chunk_ids.iter()
+                    .filter_map(|id| get_chunk(id))
+                    .collect()
+        } else {
+            Vec::new()
+        }
+    })
+}
+
+
+pub fn store_filename(file_id: &str, filename: &str) {
+    FILE_META.with(|fmeta| {
+        fmeta.borrow_mut().insert(file_id.to_string(), filename.to_string());
+    });
+}
+
+// src/core/state/raw_storage/types.rs
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ChunkId(pub String);
+
+impl fmt::Display for ChunkId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileChunk {
+    pub id: ChunkId,
+    pub file_id: String,
+    pub chunk_index: u32,
+    pub data: Vec<u8>,
+    pub size: usize
+}
+
+pub const CHUNK_SIZE: usize = 3 * 1024 * (1024 / 2); // 1.5MB chunks
+
+// src/rest/directorys/types.rs
+use serde::{Deserialize, Serialize};
+use crate::{core::state::directory::types::{FileMetadata, FolderMetadata}, rest::webhooks::types::SortDirection};
+
+#[derive(Debug, Clone, Deserialize)]
+pub enum DirectoryAction {
+    #[serde(rename = "get")]
+    Get,
+    #[serde(rename = "create")]
+    Create,
+    #[serde(rename = "update")]
+    Update,
+    #[serde(rename = "delete")]
+    Delete,
+    #[serde(rename = "copy")]
+    Copy,
+    #[serde(rename = "move")]
+    Move,
+    #[serde(rename = "sync")]
+    Sync,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DirectoryActionRequest {
+    pub action: DirectoryAction,
+    #[serde(flatten)]
+    pub params: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DirectoryActionResponse {
+    #[serde(flatten)]
+    pub data: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SearchDirectoryRequest {
+    pub query_string: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListDirectoryRequest {
+    pub folder_id: Option<String>,
+    pub path: Option<String>,
+    #[serde(default)]
+    pub filters: String,
+    #[serde(default = "default_page_size")]
+    pub page_size: usize,
+    #[serde(default)]
+    pub direction: SortDirection,
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DirectoryListResponse {
+    pub folders: Vec<FolderMetadata>,
+    pub files: Vec<FileMetadata>,
+    pub total_files: usize,
+    pub total_folders: usize,
+    pub cursor: Option<String>,
+}
+
+fn default_page_size() -> usize {
+    50
+}
+
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UploadChunkRequest {
+    pub file_id: String,
+    pub chunk_index: u32,
+    pub chunk_data: Vec<u8>,
+    pub total_chunks: u32
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UploadChunkResponse {
+    pub chunk_id: String,
+    pub bytes_received: usize
+}
+
+#[derive(Debug, Clone, Deserialize)] 
+pub struct CompleteUploadRequest {
+    pub file_id: String,
+    pub filename: String
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CompleteUploadResponse {
+    pub file_id: String,
+    pub size: usize,
+    pub chunks: u32,
+    pub filename: String
+}
+
+
+#[derive(serde::Serialize)]
+pub struct FileMetadataResponse {
+    pub file_id: String,
+    pub total_size: usize,
+    pub total_chunks: u32,
+    pub filename: String
+}
+
+pub type SearchDirectoryResponse = DirectoryListResponse;
+
+pub type DirectoryResponse<'a, T> = crate::rest::drives::types::DriveResponse<'a, T>;
+pub type ErrorResponse<'a> = DirectoryResponse<'a, ()>;
+
+
+// src/rest/directorys/route.rs
+use crate::debug_log;
+use crate::rest::router;
+use crate::types::RouteHandler;
+
+pub const DIRECTORYS_SEARCH_PATH: &str = "/directory/search";
+pub const DIRECTORYS_LIST_PATH: &str = "/directory/list";
+pub const DIRECTORYS_ACTION_PATH: &str = "/directory/action";
+pub const UPLOAD_CHUNK_PATH: &str = "/directory/raw_upload/chunk";
+pub const COMPLETE_UPLOAD_PATH: &str = "/directory/raw_upload/complete";
+pub const RAW_DOWNLOAD_META_PATH: &str = "/directory/raw_download/meta";
+pub const RAW_DOWNLOAD_CHUNK_PATH: &str = "/directory/raw_download/chunk";
+
+type HandlerEntry = (&'static str, &'static str, RouteHandler);
+
+pub fn init_routes() {
+    let routes: &[HandlerEntry] = &[
+        (
+            "POST",
+            DIRECTORYS_SEARCH_PATH,
+            crate::rest::directory::handler::directorys_handlers::search_directory_handler,
+        ),
+        (
+            "POST",
+            DIRECTORYS_LIST_PATH,
+            crate::rest::directory::handler::directorys_handlers::list_directorys_handler,
+        ),
+        (
+            "POST",
+            DIRECTORYS_ACTION_PATH,
+            crate::rest::directory::handler::directorys_handlers::action_directory_handler,
+        ),
+        (
+            "POST",
+            UPLOAD_CHUNK_PATH,
+            crate::rest::directory::handler::directorys_handlers::handle_upload_chunk,
+        ),
+        (
+            "POST",
+            COMPLETE_UPLOAD_PATH,
+            crate::rest::directory::handler::directorys_handlers::handle_complete_upload,
+        ),
+        (
+            "GET",
+            RAW_DOWNLOAD_META_PATH,
+            crate::rest::directory::handler::directorys_handlers::download_file_metadata_handler,
+        ),
+        (
+            "GET",
+            RAW_DOWNLOAD_CHUNK_PATH,
+            crate::rest::directory::handler::directorys_handlers::download_file_chunk_handler,
+        ),
+    ];
+
+    for &(method, path, handler) in routes {
+        debug_log!("Registering {} route: {}", method, path);
+        router::insert_route(method, path, handler);
+    }
+
+}
+
+// src/rest/directorys/handler.rs
+
+
+pub mod directorys_handlers {
+    use crate::{
+        core::{api::{drive::drive::fetch_files_at_folder_path, uuid::generate_unique_id}, state::{directory::{}, drives::state::state::OWNER_ID, raw_storage::{state::{get_file_chunks, store_chunk, store_filename, FILE_META}, types::{ChunkId, FileChunk, CHUNK_SIZE}}}}, debug_log, rest::{auth::{authenticate_request, create_auth_error_response, create_raw_upload_error_response}, directory::types::{CompleteUploadRequest, CompleteUploadResponse, DirectoryActionRequest, DirectoryActionResponse, DirectoryListResponse, ErrorResponse, FileMetadataResponse, ListDirectoryRequest, UploadChunkRequest, UploadChunkResponse}}, 
+        
+    };
+    use ic_http_certification::{HttpRequest, HttpResponse, StatusCode};
+    use matchit::Params;
+    use serde::Deserialize;
+    use urlencoding::decode;
+    #[derive(Deserialize, Default)]
+    struct ListQueryParams {
+        title: Option<String>,
+        completed: Option<bool>,
+    }
+
+    pub fn search_directory_handler(request: &HttpRequest, _params: &Params) -> HttpResponse<'static> {
+        let requester_api_key = match authenticate_request(request) {
+            Some(key) => key,
+            None => return create_auth_error_response(),
+        };
+    
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        if !is_owner {
+            return create_auth_error_response();
+        }
+    
+        let response = DirectoryListResponse {
+            folders: Vec::new(),
+            files: Vec::new(),
+            total_folders: 0,
+            total_files: 0,
+            cursor: None,
+        };
+    
+        create_response(
+            StatusCode::OK,
+            serde_json::to_vec(&response).expect("Failed to serialize response")
+        )
+    }
+
+    pub fn list_directorys_handler(request: &HttpRequest, _params: &Params) -> HttpResponse<'static> {
+        // Authenticate request
+        let requester_api_key = match authenticate_request(request) {
+            Some(key) => key,
+            None => return create_auth_error_response(),
+        };
+    
+        // Only owner can access directories
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        if !is_owner {
+            return create_auth_error_response();
+        }
+    
+        // Parse request body
+        let list_request: ListDirectoryRequest = match serde_json::from_slice(request.body()) {
+            Ok(req) => req,
+            Err(_) => return create_response(
+                StatusCode::BAD_REQUEST,
+                ErrorResponse::err(400, "Invalid request format".to_string()).encode()
+            ),
+        };
+    
+        match fetch_files_at_folder_path(list_request) {
+            Ok(response) => create_response(
+                StatusCode::OK,
+                serde_json::to_vec(&response).expect("Failed to serialize response")
+            ),
+            Err(err) => create_response(
+                StatusCode::NOT_FOUND,
+                ErrorResponse::err(404, format!("Failed to list directory: {:?}", err)).encode()
+            )
+        }
+    }
+
+    pub fn action_directory_handler(request: &HttpRequest, _params: &Params) -> HttpResponse<'static> {
+        let requester_api_key = match authenticate_request(request) {
+            Some(key) => key,
+            None => return create_auth_error_response(),
+        };
+    
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        if !is_owner {
+            return create_auth_error_response();
+        }
+    
+        let action_request: DirectoryActionRequest = match serde_json::from_slice(request.body()) {
+            Ok(req) => req,
+            Err(_) => return create_response(
+                StatusCode::BAD_REQUEST,
+                ErrorResponse::err(400, "Invalid request format".to_string()).encode()
+            ),
+        };
+    
+        // Placeholder that returns empty response for all actions
+        let response = DirectoryActionResponse {
+            data: serde_json::json!({})
+        };
+    
+        create_response(
+            StatusCode::OK,
+            serde_json::to_vec(&response).expect("Failed to serialize response")
+        )
+    }
+
+    pub fn handle_upload_chunk(req: &HttpRequest, _: &Params) -> HttpResponse<'static> {
+        debug_log!("Handling upload chunk request");
+
+        let upload_req: UploadChunkRequest = match serde_json::from_slice(req.body()) {
+            Ok(req) => req,
+            Err(_) => {
+                debug_log!("handle_upload_chunk: Failed to deserialize request");
+                return create_raw_upload_error_response("Invalid request format")
+            }
+        };
+
+        debug_log!("handle_upload_chunk: Handling chunk upload");
+        debug_log!("  file_id      = {}", upload_req.file_id);
+        debug_log!("  chunk_index  = {}", upload_req.chunk_index);
+        debug_log!("  total_chunks = {}", upload_req.total_chunks);
+        debug_log!("  chunk_size   = {}", upload_req.chunk_data.len());
+    
+        if upload_req.chunk_data.len() > CHUNK_SIZE {
+            return create_raw_upload_error_response("Chunk too large");
+        }
+    
+        let chunk_id = ChunkId(format!("{}-{}", upload_req.file_id, upload_req.chunk_index));
+        
+        let chunk = FileChunk {
+            id: chunk_id.clone(),
+            file_id: upload_req.file_id,
+            chunk_index: upload_req.chunk_index,
+            data: upload_req.chunk_data.clone(),
+            size: upload_req.chunk_data.len()
+        };
+        debug_log!("handle_upload_chunk: Storing chunk {:?}", chunk.id);
+    
+        store_chunk(chunk);
+    
+        let response = UploadChunkResponse {
+            chunk_id: chunk_id.0,
+            bytes_received: upload_req.chunk_data.len()
+        };
+    
+        debug_log!("handle_upload_chunk: Successfully stored chunk");
+        create_success_response(&response)
+    }
+    
+    pub fn handle_complete_upload(req: &HttpRequest, _: &Params) -> HttpResponse<'static> {
+        let complete_req: CompleteUploadRequest = match serde_json::from_slice(req.body()) {
+            Ok(req) => req,
+            Err(_) => return create_raw_upload_error_response("Invalid request format")
+        };
+        debug_log!("handle_complete_upload: Completing upload");
+        debug_log!("  file_id = {}", complete_req.file_id);
+
+        store_filename(&complete_req.file_id, &complete_req.filename);
+    
+        let chunks = get_file_chunks(&complete_req.file_id);
+        debug_log!("handle_complete_upload: Found {} chunks", chunks.len());
+
+        let total_size: usize = chunks.iter().map(|c| c.size).sum();
+        debug_log!("handle_complete_upload: Total size = {} bytes", total_size);
+    
+        let response = CompleteUploadResponse {
+            file_id: complete_req.file_id,
+            size: total_size,
+            chunks: chunks.len() as u32,
+            filename: complete_req.filename
+        };
+         debug_log!("handle_complete_upload: Returning final response with size={} chunks={}", response.size, response.chunks);
+    
+        create_success_response(&response)
+    }
+
+    /// Returns the metadata about a file: total size, total chunks, etc.
+    pub fn download_file_metadata_handler(req: &HttpRequest, _: &Params) -> HttpResponse<'static> {
+        debug_log!("download_file_metadata_handler: Handling file metadata request");
+
+        // // 1. Optionally authenticate, if required
+        // let requester_api_key = match authenticate_request(req) {
+        //     Some(key) => key,
+        //     None => return create_auth_error_response(),
+        // };
+
+        // // 2. Check if user is owner, if that's your policy
+        // let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        // if !is_owner {
+        //     return create_auth_error_response();
+        // }
+
+        // 3. Parse query string for file_id
+        let raw_query_string = req.get_query().unwrap_or(Some("".to_string()));
+        let query_string = raw_query_string.as_deref().unwrap_or("");
+        let query_map = crate::rest::helpers::parse_query_string(&query_string);
+
+        let file_id = match query_map.get("file_id") {
+            Some(fid) => fid,
+            None => {
+                return create_response(
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::err(400, "Missing file_id in query".to_string()).encode()
+                );
+            }
+        };
+        let file_id = decode(file_id).unwrap_or_else(|_| file_id.into());
+
+        debug_log!("download_file_metadata_handler: file_id={}", file_id);
+
+        // 4. Collect chunks for this file, if any
+        let mut chunks = get_file_chunks(&file_id);
+        if chunks.is_empty() {
+            return create_response(
+                StatusCode::NOT_FOUND,
+                ErrorResponse::err(404, "File not found".to_string()).encode()
+            );
+        }
+
+        // 5. Sort by chunk index and compute total size
+        chunks.sort_by_key(|c| c.chunk_index);
+        let total_size: usize = chunks.iter().map(|c| c.size).sum();
+        let total_chunks = chunks.len() as u32;
+
+        let filename: String = FILE_META.with(|map| 
+            map.borrow()
+                .get(&file_id.to_string())
+                .cloned()
+        ).unwrap_or_else(|| "unknown.bin".to_string());
+
+        // Create a JSON response with metadata
+        let metadata_response = FileMetadataResponse {
+            file_id: file_id.clone().to_string(),
+            total_size,
+            total_chunks,
+            filename
+        };
+
+        debug_log!(
+            "download_file_metadata_handler: total_size={}, total_chunks={}",
+            total_size,
+            total_chunks
+        );
+
+        create_success_response(&metadata_response)
+    }
+
+    /// Returns the data for a single chunk by index.
+    pub fn download_file_chunk_handler(req: &HttpRequest, _: &Params) -> HttpResponse<'static> {
+        debug_log!("download_file_chunk_handler: Handling file chunk request");
+
+        // // 1. Optionally authenticate
+        // let requester_api_key = match authenticate_request(req) {
+        //     Some(key) => key,
+        //     None => return create_auth_error_response(),
+        // };
+
+        // // 2. Owner check, if you want
+        // let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        // if !is_owner {
+        //     return create_auth_error_response();
+        // }
+
+        // 3. Parse query for file_id & chunk_index
+        let raw_query_string = req.get_query().unwrap_or(Some("".to_string()));
+        let query_string = raw_query_string.as_deref().unwrap_or("");
+        let query_map = crate::rest::helpers::parse_query_string(query_string);
+
+        let file_id = match query_map.get("file_id") {
+            Some(fid) => fid,
+            None => {
+                return create_response(
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::err(400, "Missing file_id".to_string()).encode()
+                );
+            }
+        };
+        let file_id = decode(file_id).unwrap_or_else(|_| file_id.into());
+
+        let chunk_index_str = match query_map.get("chunk_index") {
+            Some(cix) => cix,
+            None => {
+                return create_response(
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::err(400, "Missing chunk_index".to_string()).encode()
+                );
+            }
+        };
+        let chunk_index: u32 = match chunk_index_str.parse() {
+            Ok(num) => num,
+            Err(_) => {
+                return create_response(
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::err(400, "Invalid chunk_index".to_string()).encode()
+                );
+            }
+        };
+
+        debug_log!("download_file_chunk_handler: file_id={}, chunk_index={}", file_id, chunk_index);
+
+        // 4. Retrieve all chunks, or just the one
+        let mut chunks = get_file_chunks(&file_id);
+        chunks.sort_by_key(|c| c.chunk_index);
+
+        // Check if chunk_index is valid
+        if chunk_index as usize >= chunks.len() {
+            return create_response(
+                StatusCode::NOT_FOUND,
+                ErrorResponse::err(404, "Chunk index out of range".to_string()).encode()
+            );
+        }
+
+        let chunk = &chunks[chunk_index as usize];
+        debug_log!("download_file_chunk_handler: Found chunk size={}", chunk.size);
+
+        // 5. Return the chunk data in the HTTP body
+        //    We'll set the content-type to "application/octet-stream".
+        HttpResponse::builder()
+            .with_status_code(StatusCode::OK)
+            .with_headers(vec![
+                ("content-type".to_string(), "application/octet-stream".to_string()),
+                ("cache-control".to_string(), "no-store, max-age=0".to_string()),
+            ])
+            .with_body(chunk.data.clone())
+            .build()
+    }
+
+    fn json_decode<T>(value: &[u8]) -> T
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        serde_json::from_slice(value).expect("Failed to deserialize value")
+    }
+
+    fn create_response(status_code: StatusCode, body: Vec<u8>) -> HttpResponse<'static> {
+        HttpResponse::builder()
+            .with_status_code(status_code)
+            .with_headers(vec![
+                ("content-type".to_string(), "application/json".to_string()),
+                (
+                    "strict-transport-security".to_string(),
+                    "max-age=31536000; includeSubDomains".to_string(),
+                ),
+                ("x-content-type-options".to_string(), "nosniff".to_string()),
+                ("referrer-policy".to_string(), "no-referrer".to_string()),
+                (
+                    "cache-control".to_string(),
+                    "no-store, max-age=0".to_string(),
+                ),
+                ("pragma".to_string(), "no-cache".to_string()),
+            ])
+            .with_body(body)
+            .build()
+    }
+
+    fn create_success_response<T: serde::Serialize>(data: &T) -> HttpResponse<'static> {
+        let body = serde_json::to_vec(data).expect("Failed to serialize response");
+        create_response(StatusCode::OK, body)
+    }
+    
+}
+
+
+
+// src/lib.rs
+use ic_cdk::*;
+use ic_http_certification::{HttpRequest, HttpResponse};
+use core::state::{api_keys::state::state::init_default_admin_apikey, drives::state::state::init_self_drive};
+use std::{cell::RefCell, collections::HashMap};
+
+mod logger;
+mod types;
+mod rest;
+mod core;
+use rest::{router};
+
+#[ic_cdk_macros::init]
+fn init() {
+    debug_log!("Initializing canister...");
+    router::init_routes();
+    init_default_admin_apikey();
+    init_self_drive();  
+}
+
+#[post_upgrade]
+fn post_upgrade() {
+    init();
+}
+
+#[query]
+fn http_request(_req: HttpRequest) -> HttpResponse<'static> {
+    // All requests will be upgraded to update calls
+    HttpResponse::builder()
+        .with_upgrade(true)
+        .build()
+}
+
+#[update]
+fn http_request_update(req: HttpRequest) -> HttpResponse<'static> {
+    router::handle_request(req)
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "candid",
  "ciborium",
  "hex",
+ "hyperx",
  "ic-cdk 0.17.1",
  "ic-cdk-macros 0.17.1",
  "ic-cdk-timers",
@@ -394,6 +395,27 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyperx"
+version = "1.4.2"
+source = "git+https://github.com/ldclabs/hyperx?rev=4b9bd373b8c4d29a32e59912bf598ba69273c032#4b9bd373b8c4d29a32e59912bf598ba69273c032"
+dependencies = [
+ "base64",
+ "bytes",
+ "http",
+ "httpdate",
+ "language-tags",
+ "mime",
+ "percent-encoding",
+ "unicase",
 ]
 
 [[package]]
@@ -677,6 +699,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +739,12 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "num-bigint"
@@ -1053,6 +1087,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -42,3 +42,14 @@ And here are the possible set of events and their corresponding alt_index patter
 - `drive.*` -> `""` empty string
 
 So when a CRUD event happens on a file, we can take the file.id and use it to query against `WEBHOOKS_BY_ALT_INDEX_HASHTABLE` to quickly check in O(1) time if theres a relevant webhook. The limitation is there can only be 1 webhook per resource.
+
+## Default Canister Memory
+
+By default, a drive on ICP mainnet can use the canister itself for filestorage. While convinient, its also slow (10x slower, takes several mins to upload a 60mb video) and expensive ($5/gb/month). However we must still offer it as an option. For this we use the `/directory/raw_upload/*` and `/directory/raw_download/*` routes.
+
+We batch upload files in chunks and canister server reconstructs writing to stable memory continously (hence slow). When we download, we can either:
+
+1. Download by building the file in browser memory as chunks are downloaded. Convinent but memory inefficient, large files can cause lag. Use this for under <100mb.
+2. Download by write-streaming to local computer filesystem which solves the memory efficiency issues, but requires browser permission to access local file directory. Use this for large files >100mb.
+
+The best place to store files is not the canister, its 3rd party integrations like S3, Storj, or local SSD.

--- a/TODO.md
+++ b/TODO.md
@@ -2,12 +2,12 @@
 
 ## Urgent Next
 
-- [x] Migrate & refactor core drive code
-- [ ] Implement in-canister raw file storage
-- [ ] Implement browser-cache raw file storage
-- [ ] Implement local-ssd raw file storage
-- [ ] Implement aws s3 storage
-- [ ] Implement web3storj storage
+- [🔵] Migrate & refactor core drive code --> in front of every POST /directory/action:getFile we need to generate a new raw_url (and potentially also track access_tokens for reuse, at least for public)
+- [🔵] Implement in-canister raw file storage --> has raw_url but only if we add asset-canister functionality
+- [ ] Implement aws s3 storage --> has raw_url but we should be generating on-the-fly urls with temp access token each time
+- [ ] Implement web3storj storage --> has raw_url but we should be generating on-the-fly urls with temp access token each time
+- [ ] Implement browser-cache raw file storage --> no raw_url as it lives in browser cache, only way to access is via p2p webrtc which is a non-persistent link or via torrent link
+- [ ] Implement local-ssd raw file storage --> no raw_url as it lives in local SSD, only way to access is via p2p webrtc which is a non-persistent link or via torrent link
 - [ ] Implement multi-disk storage
 - [ ] Figure out best way to elegantly handle in-canister vs off-canister raw file storage (potentially also `disks` logic holding auth creds)
 - [ ] Write the `directory` REST routes and particularly the file action logic
@@ -24,6 +24,8 @@
 - [ ] Write the `permissions` REST routes (https://youtu.be/5GG-VUvruzE?si=lEC0epAhFlD9-2Bp&t=1165)
 - [ ] Auth check `permissions` on all REST routes
 - [ ] Consider optimistic frontend UI (we should probably use Tanstack Query for React as it handles it for us)
+- [ ] Implement proxied aws/storj where users simply send ETH/SOL to us and we provide storage (might be a scope API key for S3?)
+- [ ] Consider migrating internal state to `ic-stable-structures` for easy upgradeability, otherwise need to implement pre/post upgrade hooks
 
 ## Priority Backlog
 

--- a/prompts/better-file-upload.prompt.txt
+++ b/prompts/better-file-upload.prompt.txt
@@ -1,0 +1,3945 @@
+// better code i want to use as reference for refactor
+
+// cargo.toml
+[package]
+name = "ic_oss_bucket"
+description = "A decentralized Object Storage Service bucket on the Internet Computer, part of IC-OSS."
+publish = false
+repository = "https://github.com/ldclabs/ic-oss/tree/main/src/ic_oss_bucket"
+version.workspace = true
+edition.workspace = true
+keywords.workspace = true
+categories.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+candid = { workspace = true }
+ciborium = { workspace = true }
+ic-cdk = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+base64 = { workspace = true }
+once_cell = { workspace = true }
+ic-stable-structures = { workspace = true }
+ic-http-certification = { workspace = true }
+getrandom = { workspace = true }
+lazy_static = "1.4"
+hyperx = { git = "https://github.com/ldclabs/hyperx", rev = "4b9bd373b8c4d29a32e59912bf598ba69273c032" }
+ic-oss-types = { path = "../ic_oss_types", version = "0.9" }
+
+
+// store.rs
+use candid::Principal;
+use ciborium::{from_reader, into_writer};
+use ic_http_certification::{
+    cel::{create_cel_expr, DefaultCelBuilder},
+    HttpCertification, HttpCertificationPath, HttpCertificationTree, HttpCertificationTreeEntry,
+};
+use ic_oss_types::{
+    cose::{Token, BUCKET_TOKEN_AAD},
+    file::{
+        FileChunk, FileInfo, UpdateFileInput, CHUNK_SIZE, CUSTOM_KEY_BY_HASH, MAX_FILE_SIZE,
+        MAX_FILE_SIZE_PER_CALL,
+    },
+    folder::{FolderInfo, FolderName, UpdateFolderInput},
+    permission::Policies,
+    MapValue,
+};
+use ic_stable_structures::{
+    memory_manager::{MemoryId, MemoryManager, VirtualMemory},
+    storable::Bound,
+    DefaultMemoryImpl, StableBTreeMap, StableCell, Storable,
+};
+use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use serde_bytes::{ByteArray, ByteBuf};
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet},
+    ops::{self, Deref, DerefMut},
+};
+
+type Memory = VirtualMemory<DefaultMemoryImpl>;
+
+static ZERO_HASH: [u8; 32] = [0; 32];
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct Bucket {
+    #[serde(rename = "n", alias = "name")]
+    pub name: String,
+    #[serde(rename = "fi", alias = "file_id")]
+    pub file_id: u32,
+    #[serde(rename = "fo", alias = "folder_id")]
+    pub folder_id: u32,
+    #[serde(rename = "fz", alias = "max_file_size")]
+    pub max_file_size: u64,
+    #[serde(rename = "fd", alias = "max_folder_depth")]
+    pub max_folder_depth: u8,
+    #[serde(rename = "mc", alias = "max_children")]
+    pub max_children: u16,
+    #[serde(rename = "cds", alias = "max_custom_data_size")]
+    pub max_custom_data_size: u16,
+    #[serde(rename = "h", alias = "enable_hash_index")]
+    pub enable_hash_index: bool,
+    #[serde(rename = "s", alias = "status")]
+    pub status: i8, // -1: archived; 0: readable and writable; 1: readonly
+    #[serde(rename = "v", alias = "visibility")]
+    pub visibility: u8, // 0: private; 1: public
+    #[serde(rename = "m", alias = "managers")]
+    pub managers: BTreeSet<Principal>, // managers can read and write
+    // auditors can read and list even if the bucket is private
+    #[serde(rename = "a", alias = "auditors")]
+    pub auditors: BTreeSet<Principal>,
+    // used to verify the request token signed with SECP256K1
+    #[serde(rename = "ec", alias = "trusted_ecdsa_pub_keys")]
+    pub trusted_ecdsa_pub_keys: Vec<ByteBuf>,
+    // used to verify the request token signed with ED25519
+    #[serde(rename = "ed", alias = "trusted_eddsa_pub_keys")]
+    pub trusted_eddsa_pub_keys: Vec<ByteArray<32>>,
+    #[serde(default, rename = "gov")]
+    pub governance_canister: Option<Principal>,
+}
+
+impl Default for Bucket {
+    fn default() -> Self {
+        Self {
+            name: "default".to_string(),
+            file_id: 0,
+            folder_id: 1, // The root folder 0 is created by default
+            max_file_size: MAX_FILE_SIZE,
+            max_folder_depth: 10,
+            max_children: 100,
+            max_custom_data_size: 1024 * 4,
+            enable_hash_index: false,
+            status: 0,
+            visibility: 0,
+            managers: BTreeSet::new(),
+            auditors: BTreeSet::new(),
+            trusted_ecdsa_pub_keys: Vec::new(),
+            trusted_eddsa_pub_keys: Vec::new(),
+            governance_canister: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Context {
+    pub caller: Principal,
+    pub ps: Policies,
+    pub role: Role,
+}
+
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub enum Role {
+    User,
+    Auditor,
+    Manager,
+}
+
+impl Bucket {
+    pub fn read_permission(
+        &self,
+        caller: Principal,
+        canister: &Principal,
+        sign1_token: Option<ByteBuf>,
+        now_sec: u64,
+    ) -> Result<Context, (u16, String)> {
+        let mut ctx = Context {
+            caller,
+            ps: Policies::read(),
+            role: if self.managers.contains(&caller) {
+                Role::Manager
+            } else if self.auditors.contains(&caller) {
+                Role::Auditor
+            } else {
+                Role::User
+            },
+        };
+
+        if self.status < 0 {
+            if ctx.role >= Role::Auditor {
+                return Ok(ctx);
+            }
+
+            Err((403, "bucket is archived".to_string()))?;
+        }
+
+        if self.visibility > 0 || ctx.role >= Role::Auditor {
+            return Ok(ctx);
+        }
+
+        if let Some(token) = sign1_token {
+            let token = Token::from_sign1(
+                &token,
+                &self.trusted_ecdsa_pub_keys,
+                &self.trusted_eddsa_pub_keys,
+                BUCKET_TOKEN_AAD,
+                now_sec as i64,
+            )
+            .map_err(|err| (401, err))?;
+
+            if &token.audience == canister {
+                ctx.ps =
+                    Policies::try_from(token.policies.as_str()).map_err(|err| (403u16, err))?;
+                ctx.caller = token.subject;
+                return Ok(ctx);
+            }
+        }
+
+        Err((401, "Unauthorized".to_string()))
+    }
+
+    pub fn write_permission(
+        &self,
+        caller: Principal,
+        canister: &Principal,
+        sign1_token: Option<ByteBuf>,
+        now_sec: u64,
+    ) -> Result<Context, (u16, String)> {
+        if self.status != 0 {
+            Err((403, "bucket is not writable".to_string()))?;
+        }
+
+        let mut ctx = Context {
+            caller,
+            ps: Policies::all(),
+            role: if self.managers.contains(&caller) {
+                Role::Manager
+            } else if self.auditors.contains(&caller) {
+                Role::Auditor
+            } else {
+                Role::User
+            },
+        };
+
+        if ctx.role >= Role::Manager {
+            return Ok(ctx);
+        }
+
+        if let Some(token) = sign1_token {
+            let token = Token::from_sign1(
+                &token,
+                &self.trusted_ecdsa_pub_keys,
+                &self.trusted_eddsa_pub_keys,
+                BUCKET_TOKEN_AAD,
+                now_sec as i64,
+            )
+            .map_err(|err| (401, err))?;
+            if &token.audience == canister {
+                ctx.ps =
+                    Policies::try_from(token.policies.as_str()).map_err(|err| (403u16, err))?;
+                ctx.caller = token.subject;
+                return Ok(ctx);
+            }
+        }
+
+        Err((401, "Unauthorized".to_string()))
+    }
+}
+
+impl Storable for Bucket {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut buf = vec![];
+        into_writer(self, &mut buf).expect("failed to encode Bucket data");
+        Cow::Owned(buf)
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        from_reader(&bytes[..]).expect("failed to decode Bucket data")
+    }
+}
+
+// FileId: (file id, chunk id)
+// a file is a collection of chunks.
+#[derive(Clone, Default, Deserialize, Serialize, Ord, PartialOrd, Eq, PartialEq)]
+pub struct FileId(pub u32, pub u32);
+impl Storable for FileId {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 11,
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut buf = vec![];
+        into_writer(self, &mut buf).expect("failed to encode FileId data");
+        Cow::Owned(buf)
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        from_reader(&bytes[..]).expect("failed to decode FileId data")
+    }
+}
+
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub struct FileMetadata {
+    #[serde(rename = "p", alias = "parent")]
+    pub parent: u32, // 0: root
+    #[serde(rename = "n", alias = "name")]
+    pub name: String,
+    #[serde(rename = "t", alias = "content_type")]
+    pub content_type: String, // MIME types
+    #[serde(rename = "i", alias = "size")]
+    pub size: u64,
+    #[serde(rename = "f", alias = "filled")]
+    pub filled: u64,
+    #[serde(rename = "ca", alias = "created_at")]
+    pub created_at: u64, // unix timestamp in milliseconds
+    #[serde(rename = "ua", alias = "updated_at")]
+    pub updated_at: u64, // unix timestamp in milliseconds
+    #[serde(rename = "c", alias = "chunks")]
+    pub chunks: u32,
+    #[serde(rename = "s", alias = "status")]
+    pub status: i8, // -1: archived; 0: readable and writable; 1: readonly
+    #[serde(rename = "h", alias = "hash")]
+    pub hash: Option<ByteArray<32>>, // recommend sha3 256
+    #[serde(rename = "k", alias = "dek")]
+    pub dek: Option<ByteBuf>, // // Data Encryption Key that encrypted by BYOK or vetKey in COSE_Encrypt0
+    #[serde(rename = "cu", alias = "custom")]
+    pub custom: Option<MapValue>, // custom metadata
+    #[serde(rename = "e", alias = "ex")]
+    pub ex: Option<MapValue>, // External Resource, ER indicates that the file is an external resource.
+}
+
+impl Storable for FileMetadata {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut buf = vec![];
+        into_writer(self, &mut buf).expect("failed to encode FileMetadata data");
+        Cow::Owned(buf)
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        from_reader(&bytes[..]).expect("failed to decode FileMetadata data")
+    }
+}
+
+impl FileMetadata {
+    pub fn into_info(self, id: u32) -> FileInfo {
+        FileInfo {
+            id,
+            parent: self.parent,
+            name: self.name,
+            content_type: self.content_type,
+            size: self.size,
+            filled: self.filled,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+            chunks: self.chunks,
+            status: self.status,
+            hash: self.hash,
+            dek: self.dek,
+            custom: self.custom,
+            ex: self.ex,
+        }
+    }
+
+    pub fn read_by_hash(&self, access_token: &Option<ByteBuf>) -> bool {
+        if let Some(access_token) = access_token {
+            self.status >= 0
+                && self
+                    .custom
+                    .as_ref()
+                    .map_or(false, |c| c.contains_key(CUSTOM_KEY_BY_HASH))
+                && self
+                    .hash
+                    .as_ref()
+                    .map_or(false, |h| h.as_slice() == access_token.as_ref())
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Clone, Default, Deserialize, Serialize)]
+pub struct Chunk(pub Vec<u8>);
+
+impl Storable for Chunk {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: CHUNK_SIZE,
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Borrowed(&self.0)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Self(bytes.to_vec())
+    }
+}
+
+// folder
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct FolderMetadata {
+    #[serde(rename = "p", alias = "parent")]
+    pub parent: u32, // 0: root
+    #[serde(rename = "n", alias = "name")]
+    pub name: String,
+    #[serde(rename = "fi", alias = "files")]
+    pub files: BTreeSet<u32>, // length <= max_children
+    #[serde(rename = "fo", alias = "folders")]
+    pub folders: BTreeSet<u32>, // length <= max_children
+    #[serde(rename = "ca", alias = "created_at")]
+    pub created_at: u64, // unix timestamp in milliseconds
+    #[serde(rename = "ua", alias = "updated_at")]
+    pub updated_at: u64, // unix timestamp in milliseconds
+    #[serde(rename = "s", alias = "status")]
+    pub status: i8, // -1: archived; 0: readable and writable; 1: readonly
+}
+
+impl FolderMetadata {
+    pub fn into_info(self, id: u32) -> FolderInfo {
+        FolderInfo {
+            id,
+            parent: self.parent,
+            name: self.name,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+            status: self.status,
+            files: self.files,
+            folders: self.folders,
+        }
+    }
+}
+
+impl Storable for FolderMetadata {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut buf = vec![];
+        into_writer(self, &mut buf).expect("failed to encode FolderMetadata data");
+        Cow::Owned(buf)
+    }
+
+    fn from_bytes(bytes: Cow<'_, [u8]>) -> Self {
+        from_reader(&bytes[..]).expect("failed to decode FolderMetadata data")
+    }
+}
+
+#[derive(Clone, Default, Deserialize, Serialize)]
+struct FoldersTree(BTreeMap<u32, FolderMetadata>);
+
+impl Deref for FoldersTree {
+    type Target = BTreeMap<u32, FolderMetadata>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for FoldersTree {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl AsRef<BTreeMap<u32, FolderMetadata>> for FoldersTree {
+    fn as_ref(&self) -> &BTreeMap<u32, FolderMetadata> {
+        &self.0
+    }
+}
+
+impl FoldersTree {
+    fn new() -> Self {
+        Self(BTreeMap::from([(
+            0,
+            FolderMetadata {
+                name: "root".to_string(),
+                ..Default::default()
+            },
+        )]))
+    }
+
+    fn depth(&self, mut id: u32) -> usize {
+        let mut depth = 0;
+        // depth hard limit is 1024
+        while id != 0 && depth < 1024 {
+            match self.get(&id) {
+                None => break,
+                Some(folder) => {
+                    id = folder.parent;
+                    depth += 1;
+                }
+            }
+        }
+        depth
+    }
+
+    fn depth_or_is_ancestor(&self, mut id: u32, parent: u32) -> (usize, bool) {
+        let mut depth = 0;
+        while id != 0 && depth < 1024 {
+            if id == parent {
+                return (depth, true);
+            }
+
+            match self.get(&id) {
+                None => break,
+                Some(folder) => {
+                    id = folder.parent;
+                    depth += 1;
+                }
+            }
+        }
+        (depth, parent == 0)
+    }
+
+    fn ancestors(&self, mut parent: u32) -> Vec<FolderName> {
+        let mut res = Vec::with_capacity(10);
+        while parent != 0 {
+            match self.get(&parent) {
+                None => break,
+                Some(folder) => {
+                    res.push(FolderName {
+                        id: parent,
+                        name: folder.name.clone(),
+                    });
+                    parent = folder.parent;
+                }
+            }
+        }
+        res
+    }
+
+    fn ancestors_map<F, U>(&self, mut parent: u32, f: F) -> Vec<U>
+    where
+        F: Fn(u32, &FolderMetadata) -> U,
+    {
+        let mut res = Vec::with_capacity(10);
+        while parent != 0 {
+            match self.get(&parent) {
+                None => break,
+                Some(folder) => {
+                    res.push(f(parent, folder));
+                    parent = folder.parent;
+                }
+            }
+        }
+        res
+    }
+
+    fn list_folders(&self, ctx: &Context, parent: u32, prev: u32, take: u32) -> Vec<FolderInfo> {
+        match self.0.get(&parent) {
+            None => Vec::new(),
+            Some(parent) => {
+                if parent.status < 0 && ctx.role < Role::Auditor {
+                    return Vec::new();
+                }
+
+                let mut res = Vec::with_capacity(parent.folders.len());
+                for &folder_id in parent.folders.range(ops::RangeTo { end: prev }).rev() {
+                    match self.get(&folder_id) {
+                        None => break,
+                        Some(folder) => {
+                            res.push(folder.clone().into_info(folder_id));
+                            if res.len() >= take as usize {
+                                break;
+                            }
+                        }
+                    }
+                }
+                res
+            }
+        }
+    }
+
+    fn list_files(
+        &self,
+        ctx: &Context,
+        fs_metadata: &StableBTreeMap<u32, FileMetadata, Memory>,
+        parent: u32,
+        prev: u32,
+        take: u32,
+    ) -> Vec<FileInfo> {
+        match self.get(&parent) {
+            None => Vec::new(),
+            Some(parent) => {
+                if parent.status < 0 && ctx.role < Role::Auditor {
+                    return Vec::new();
+                }
+
+                let mut res = Vec::with_capacity(take as usize);
+                for &file_id in parent.files.range(ops::RangeTo { end: prev }).rev() {
+                    match fs_metadata.get(&file_id) {
+                        None => break,
+                        Some(meta) => {
+                            res.push(meta.into_info(file_id));
+                            if res.len() >= take as usize {
+                                break;
+                            }
+                        }
+                    }
+                }
+                res
+            }
+        }
+    }
+
+    fn add_folder(
+        &mut self,
+        metadata: FolderMetadata,
+        id: u32, // id should be unique
+        max_folder_depth: usize,
+        max_children: usize,
+    ) -> Result<(), String> {
+        if self.get(&id).is_some() {
+            Err(format!("folder id already exists: {}", id))?;
+        }
+
+        if self.depth(metadata.parent) >= max_folder_depth {
+            Err("folder depth exceeds limit".to_string())?;
+        }
+
+        let parent = self
+            .get_mut(&metadata.parent)
+            .ok_or_else(|| format!("parent folder not found: {}", metadata.parent))?;
+
+        if parent.status != 0 {
+            Err("parent folder is not writable".to_string())?;
+        }
+
+        // no limit for root folder
+        if metadata.parent > 0 && parent.folders.len() + parent.files.len() >= max_children {
+            Err("children exceeds limit".to_string())?;
+        }
+        parent.folders.insert(id);
+        self.insert(id, metadata);
+        Ok(())
+    }
+
+    fn parent_to_update(&mut self, parent: u32) -> Result<&mut FolderMetadata, String> {
+        let folder = self
+            .get_mut(&parent)
+            .ok_or_else(|| format!("parent folder not found: {}", parent))?;
+
+        if folder.status != 0 {
+            Err("parent folder is not writable".to_string())?;
+        }
+
+        Ok(folder)
+    }
+
+    fn parent_to_add_file(
+        &mut self,
+        parent: u32,
+        max_children: usize,
+    ) -> Result<&mut FolderMetadata, String> {
+        let folder = self
+            .get_mut(&parent)
+            .ok_or_else(|| format!("parent folder not found: {}", parent))?;
+
+        if folder.status != 0 {
+            Err("parent folder is not writable".to_string())?;
+        }
+
+        // no limit for root folder
+        if parent > 0 && folder.folders.len() + folder.files.len() >= max_children {
+            Err("children exceeds limit".to_string())?;
+        }
+
+        Ok(folder)
+    }
+
+    fn check_moving_folder(
+        &self,
+        id: u32,
+        from: u32,
+        to: u32,
+        max_folder_depth: usize,
+        max_children: usize,
+    ) -> Result<(), String> {
+        if id == 0 {
+            Err("root folder cannot be moved".to_string())?;
+        }
+
+        if from == to {
+            Err(format!("target parent folder should not be {}", from))?;
+        }
+
+        let folder = self
+            .get(&id)
+            .ok_or_else(|| format!("folder not found: {}", id))?;
+
+        if folder.parent != from {
+            Err(format!("folder {} is not in folder {}", id, from))?;
+        }
+        if folder.status != 0 {
+            Err(format!("folder {} is not writable", id))?;
+        }
+
+        let from_folder = self
+            .get(&from)
+            .ok_or_else(|| format!("folder not found: {}", from))?;
+        if from_folder.status != 0 {
+            Err(format!("folder {} is not writable", from))?;
+        }
+
+        let to_folder = self
+            .get(&to)
+            .ok_or_else(|| format!("folder not found: {}", to))?;
+        if to_folder.status != 0 {
+            Err(format!("folder {} is not writable", to))?;
+        }
+
+        if to > 0 && to_folder.folders.len() + to_folder.files.len() >= max_children {
+            Err("children exceeds limit".to_string())?;
+        }
+
+        let (depth, is_ancestor) = self.depth_or_is_ancestor(to, id);
+        if is_ancestor {
+            Err("folder cannot be moved to its sub folder".to_string())?;
+        }
+
+        if depth >= max_folder_depth {
+            Err("folder depth exceeds limit".to_string())?;
+        }
+
+        Ok(())
+    }
+
+    fn move_folder(&mut self, id: u32, from: u32, to: u32, now_ms: u64) {
+        self.entry(from).and_modify(|from_folder| {
+            from_folder.folders.remove(&id);
+            from_folder.updated_at = now_ms;
+        });
+        self.entry(to).and_modify(|to_folder| {
+            to_folder.folders.insert(id);
+            to_folder.updated_at = now_ms;
+        });
+        self.entry(id).and_modify(|folder| {
+            folder.parent = to;
+            folder.updated_at = now_ms;
+        });
+    }
+
+    fn check_moving_file(&self, from: u32, to: u32, max_children: usize) -> Result<(), String> {
+        if from == to {
+            Err(format!("target parent should not be {}", from))?;
+        }
+
+        let from_folder = self
+            .get(&from)
+            .ok_or_else(|| format!("folder not found: {}", from))?;
+        if from_folder.status != 0 {
+            Err(format!("folder {} is not writable", from))?;
+        }
+
+        let to_folder = self
+            .get(&to)
+            .ok_or_else(|| format!("folder not found: {}", to))?;
+        if to_folder.status != 0 {
+            Err(format!("folder {} is not writable", to))?;
+        }
+
+        if to > 0 && to_folder.folders.len() + to_folder.files.len() >= max_children {
+            Err("children exceeds limit".to_string())?;
+        }
+
+        Ok(())
+    }
+
+    fn move_file(&mut self, id: u32, from: u32, to: u32, now_ms: u64) {
+        self.entry(from).and_modify(|from_folder| {
+            from_folder.files.remove(&id);
+            from_folder.updated_at = now_ms;
+        });
+        self.entry(to).and_modify(|to_folder| {
+            to_folder.files.insert(id);
+            to_folder.updated_at = now_ms;
+        });
+    }
+
+    fn delete_folder(&mut self, id: u32, now_ms: u64) -> Result<bool, String> {
+        if id == 0 {
+            Err("root folder cannot be deleted".to_string())?;
+        }
+
+        let parent_id = match self.get(&id) {
+            None => return Ok(false),
+            Some(folder) => {
+                if folder.status > 0 {
+                    Err("folder is readonly".to_string())?;
+                }
+                if !folder.folders.is_empty() || !folder.files.is_empty() {
+                    Err("folder is not empty".to_string())?;
+                }
+                folder.parent
+            }
+        };
+
+        let parent = self
+            .get_mut(&parent_id)
+            .ok_or_else(|| format!("parent folder not found: {}", parent_id))?;
+
+        if parent.status != 0 {
+            Err("parent folder is not writable".to_string())?;
+        }
+
+        if parent.folders.remove(&id) {
+            parent.updated_at = now_ms;
+        }
+
+        Ok(self.remove(&id).is_some())
+    }
+}
+
+const BUCKET_MEMORY_ID: MemoryId = MemoryId::new(0);
+const HASH_INDEX_MEMORY_ID: MemoryId = MemoryId::new(1);
+const FOLDERS_MEMORY_ID: MemoryId = MemoryId::new(2);
+const FS_METADATA_MEMORY_ID: MemoryId = MemoryId::new(3);
+const FS_CHUNKS_MEMORY_ID: MemoryId = MemoryId::new(4);
+
+thread_local! {
+    static HTTP_TREE: RefCell<HttpCertificationTree> = RefCell::new(HttpCertificationTree::default());
+    static BUCKET: RefCell<Bucket> = RefCell::new(Bucket::default());
+    static HASHS: RefCell<BTreeMap<ByteArray<32>, u32>> = RefCell::new(BTreeMap::default());
+    static FOLDERS: RefCell<FoldersTree> = RefCell::new(FoldersTree::new());
+
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+
+    static BUCKET_STORE: RefCell<StableCell<Bucket, Memory>> = RefCell::new(
+        StableCell::init(
+            MEMORY_MANAGER.with_borrow(|m| m.get(BUCKET_MEMORY_ID)),
+            Bucket::default()
+        ).expect("failed to init BUCKET_STORE store")
+    );
+
+    static FOLDER_STORE: RefCell<StableCell<Vec<u8>, Memory>> = RefCell::new(
+        StableCell::init(
+            MEMORY_MANAGER.with_borrow(|m| m.get(FOLDERS_MEMORY_ID)),
+            Vec::new()
+        ).expect("failed to init FOLDER_STORE store")
+    );
+
+    static HASH_INDEX_STORE: RefCell<StableCell<Vec<u8>, Memory>> = RefCell::new(
+        StableCell::init(
+            MEMORY_MANAGER.with_borrow(|m| m.get(HASH_INDEX_MEMORY_ID)),
+            Vec::new()
+        ).expect("failed to init HASH_INDEX_STORE store")
+    );
+
+    static FS_METADATA_STORE: RefCell<StableBTreeMap<u32, FileMetadata, Memory>> = RefCell::new(
+        StableBTreeMap::init(
+            MEMORY_MANAGER.with_borrow(|m| m.get(FS_METADATA_MEMORY_ID)),
+        )
+    );
+
+    static FS_CHUNKS_STORE: RefCell<StableBTreeMap<FileId, Chunk, Memory>> = RefCell::new(
+        StableBTreeMap::init(
+            MEMORY_MANAGER.with_borrow(|m| m.get(FS_CHUNKS_MEMORY_ID)),
+        )
+    );
+}
+
+pub mod state {
+    use super::*;
+
+    lazy_static! {
+        pub static ref DEFAULT_EXPR_PATH: HttpCertificationPath<'static> =
+            HttpCertificationPath::wildcard("");
+        pub static ref DEFAULT_CERTIFICATION: HttpCertification = HttpCertification::skip();
+        pub static ref DEFAULT_CEL_EXPR: String =
+            create_cel_expr(&DefaultCelBuilder::skip_certification());
+    }
+
+    pub static DEFAULT_CERT_ENTRY: Lazy<HttpCertificationTreeEntry> =
+        Lazy::new(|| HttpCertificationTreeEntry::new(&*DEFAULT_EXPR_PATH, *DEFAULT_CERTIFICATION));
+
+    pub fn with<R>(f: impl FnOnce(&Bucket) -> R) -> R {
+        BUCKET.with(|r| f(&r.borrow()))
+    }
+
+    pub fn with_mut<R>(f: impl FnOnce(&mut Bucket) -> R) -> R {
+        BUCKET.with(|r| f(&mut r.borrow_mut()))
+    }
+
+    pub fn is_controller(caller: &Principal) -> bool {
+        BUCKET.with(|r| {
+            r.borrow()
+                .governance_canister
+                .as_ref()
+                .map_or(false, |p| p == caller)
+        })
+    }
+
+    pub fn http_tree_with<R>(f: impl FnOnce(&HttpCertificationTree) -> R) -> R {
+        HTTP_TREE.with(|r| f(&r.borrow()))
+    }
+
+    pub fn init_http_certified_data() {
+        HTTP_TREE.with(|r| {
+            let mut tree = r.borrow_mut();
+            tree.insert(&DEFAULT_CERT_ENTRY);
+            ic_cdk::api::set_certified_data(&tree.root_hash())
+        });
+    }
+
+    pub fn load() {
+        BUCKET_STORE.with(|r| {
+            let s = r.borrow().get().clone();
+            BUCKET.with(|h| {
+                *h.borrow_mut() = s;
+            });
+        });
+        HASH_INDEX_STORE.with(|r| {
+            HASHS.with(|h| {
+                let v: BTreeMap<ByteArray<32>, u32> = from_reader(&r.borrow().get()[..])
+                    .expect("failed to decode HASH_INDEX_STORE data");
+                *h.borrow_mut() = v;
+            });
+        });
+        FOLDER_STORE.with(|r| {
+            FOLDERS.with(|h| {
+                let v: FoldersTree =
+                    from_reader(&r.borrow().get()[..]).expect("failed to decode FOLDER_STORE data");
+                *h.borrow_mut() = v;
+            });
+        });
+    }
+
+    pub fn save() {
+        BUCKET.with(|h| {
+            BUCKET_STORE.with(|r| {
+                r.borrow_mut()
+                    .set(h.borrow().clone())
+                    .expect("failed to set BUCKET_STORE data");
+            });
+        });
+        HASHS.with(|h| {
+            HASH_INDEX_STORE.with(|r| {
+                let mut buf = vec![];
+                into_writer(&(*h.borrow()), &mut buf)
+                    .expect("failed to encode HASH_INDEX_STORE data");
+                r.borrow_mut()
+                    .set(buf)
+                    .expect("failed to set HASH_INDEX_STORE data");
+            });
+        });
+        FOLDERS.with(|h| {
+            FOLDER_STORE.with(|r| {
+                let mut buf = vec![];
+                into_writer(&(*h.borrow()), &mut buf).expect("failed to encode FOLDER_STORE data");
+                r.borrow_mut()
+                    .set(buf)
+                    .expect("failed to set FOLDER_STORE data");
+            });
+        });
+    }
+}
+
+pub mod fs {
+    use super::*;
+
+    pub fn total_files() -> u64 {
+        FS_METADATA_STORE.with(|r| r.borrow().len())
+    }
+
+    pub fn total_chunks() -> u64 {
+        FS_CHUNKS_STORE.with(|r| r.borrow().len())
+    }
+
+    pub fn total_folders() -> u64 {
+        FOLDERS.with(|r| r.borrow().len() as u64)
+    }
+
+    pub fn get_file_id(hash: &[u8; 32]) -> Option<u32> {
+        HASHS.with(|r| r.borrow().get(hash).copied())
+    }
+
+    pub fn get_folder(id: u32) -> Option<FolderMetadata> {
+        FOLDERS.with(|r| r.borrow().get(&id).cloned())
+    }
+
+    pub fn get_file(id: u32) -> Option<FileMetadata> {
+        FS_METADATA_STORE.with(|r| r.borrow().get(&id))
+    }
+
+    pub fn get_ancestors(start: u32) -> Vec<String> {
+        FOLDERS.with(|r| {
+            let m = r.borrow();
+            m.ancestors_map(start, |id, _| id.to_string())
+        })
+    }
+
+    pub fn get_folder_ancestors(id: u32) -> Vec<FolderName> {
+        FOLDERS.with(|r| {
+            let m = r.borrow();
+            match m.get(&id) {
+                None => Vec::new(),
+                Some(folder) => m.ancestors(folder.parent),
+            }
+        })
+    }
+
+    pub fn get_file_ancestors(id: u32) -> Vec<FolderName> {
+        match FS_METADATA_STORE.with(|r| r.borrow().get(&id).map(|meta| meta.parent)) {
+            None => Vec::new(),
+            Some(parent) => FOLDERS.with(|r| r.borrow().ancestors(parent)),
+        }
+    }
+
+    pub fn list_folders(ctx: &Context, parent: u32, prev: u32, take: u32) -> Vec<FolderInfo> {
+        FOLDERS.with(|r| r.borrow().list_folders(ctx, parent, prev, take))
+    }
+
+    pub fn list_files(ctx: &Context, parent: u32, prev: u32, take: u32) -> Vec<FileInfo> {
+        FOLDERS.with(|r1| {
+            FS_METADATA_STORE.with(|r2| {
+                r1.borrow()
+                    .list_files(ctx, &r2.borrow(), parent, prev, take)
+            })
+        })
+    }
+
+    pub fn add_folder(metadata: FolderMetadata) -> Result<u32, String> {
+        state::with_mut(|s| {
+            FOLDERS.with(|r| {
+                let id = s.folder_id;
+                if id == u32::MAX {
+                    Err("folder id overflow".to_string())?;
+                }
+
+                let mut m = r.borrow_mut();
+                m.add_folder(
+                    metadata,
+                    id,
+                    s.max_folder_depth as usize,
+                    s.max_children as usize,
+                )?;
+
+                s.folder_id = s.folder_id.saturating_add(1);
+                Ok(id)
+            })
+        })
+    }
+
+    pub fn add_file(metadata: FileMetadata) -> Result<u32, String> {
+        state::with_mut(|s| {
+            FOLDERS.with(|r| {
+                let id = s.file_id;
+                if id == u32::MAX {
+                    Err("file id overflow".to_string())?;
+                }
+
+                let mut m = r.borrow_mut();
+                let parent = m.parent_to_add_file(metadata.parent, s.max_children as usize)?;
+
+                if s.enable_hash_index {
+                    match metadata.hash {
+                        Some(hash) => {
+                            // ignore zero hash, client should delete the file when hash conflict
+                            if hash.as_ref() != &ZERO_HASH {
+                                HASHS.with(|r| {
+                                    let mut m = r.borrow_mut();
+                                    if let Some(prev) = m.get(hash.as_ref()) {
+                                        Err(format!("file hash conflict, {}", prev))?;
+                                    }
+
+                                    m.insert(hash, id);
+                                    Ok::<(), String>(())
+                                })?;
+                            }
+                        }
+                        None => {
+                            Err("file hash is required when enable_hash_index".to_string())?;
+                        }
+                    }
+                }
+
+                s.file_id = s.file_id.saturating_add(1);
+                parent.files.insert(id);
+                FS_METADATA_STORE.with(|r| r.borrow_mut().insert(id, metadata));
+                Ok(id)
+            })
+        })
+    }
+
+    pub fn move_folder(id: u32, from: u32, to: u32, now_ms: u64) -> Result<(), String> {
+        state::with_mut(|s| {
+            FOLDERS.with(|r| {
+                {
+                    r.borrow().check_moving_folder(
+                        id,
+                        from,
+                        to,
+                        s.max_folder_depth as usize,
+                        s.max_children as usize,
+                    )?;
+                };
+
+                r.borrow_mut().move_folder(id, from, to, now_ms);
+                Ok(())
+            })
+        })
+    }
+
+    pub fn move_file(id: u32, from: u32, to: u32, now_ms: u64) -> Result<(), String> {
+        state::with_mut(|s| {
+            FOLDERS.with(|r| {
+                {
+                    r.borrow()
+                        .check_moving_file(from, to, s.max_children as usize)?;
+                };
+
+                FS_METADATA_STORE.with(|r| {
+                    let mut m = r.borrow_mut();
+                    let mut file = m
+                        .get(&id)
+                        .ok_or_else(|| format!("file not found: {}", id))?;
+
+                    if file.status != 0 {
+                        Err(format!("file {} is not writable", id))?;
+                    }
+
+                    if file.parent != from {
+                        Err(format!("file {} is not in folder {}", id, from))?;
+                    }
+
+                    file.parent = to;
+                    file.updated_at = now_ms;
+                    m.insert(id, file);
+                    Ok::<(), String>(())
+                })?;
+
+                r.borrow_mut().move_file(id, from, to, now_ms);
+                Ok(())
+            })
+        })
+    }
+
+    pub fn update_folder(
+        change: UpdateFolderInput,
+        now_ms: u64,
+        checker: impl FnOnce(&FolderMetadata) -> Result<(), String>,
+    ) -> Result<(), String> {
+        if change.id == 0 {
+            Err("root folder cannot be updated".to_string())?;
+        }
+
+        FOLDERS.with(|r| {
+            let mut m = r.borrow_mut();
+            match m.get_mut(&change.id) {
+                None => Err(format!("folder not found: {}", change.id)),
+                Some(folder) => {
+                    checker(folder)?;
+
+                    let status = change.status.unwrap_or(folder.status);
+                    if folder.status > 0 && status > 0 {
+                        Err("folder is readonly".to_string())?;
+                    }
+                    if let Some(name) = change.name {
+                        folder.name = name;
+                    }
+                    folder.status = status;
+                    folder.updated_at = now_ms;
+                    Ok(())
+                }
+            }
+        })
+    }
+
+    pub fn update_file(
+        change: UpdateFileInput,
+        now_ms: u64,
+        checker: impl FnOnce(&FileMetadata) -> Result<(), String>,
+    ) -> Result<(), String> {
+        FS_METADATA_STORE.with(|r| {
+            let mut m = r.borrow_mut();
+            match m.get(&change.id) {
+                None => Err(format!("file not found: {}", change.id)),
+                Some(mut file) => {
+                    checker(&file)?;
+
+                    if let Some(size) = change.size {
+                        file.size = size;
+                    }
+                    if file.size == 0 {
+                        file.size = file.filled;
+                    }
+
+                    let prev_hash = file.hash;
+                    let status = change.status.unwrap_or(file.status);
+                    if file.status > 0 && status > 0 {
+                        Err("file is readonly".to_string())?;
+                    }
+                    if status == 1 && file.hash.is_none() && change.hash.is_none() {
+                        Err("readonly file must have hash".to_string())?;
+                    }
+                    if status == 1 && file.size != file.filled {
+                        Err("file not fully uploaded".to_string())?;
+                    }
+
+                    if file.size < file.filled {
+                        // the file content will be deleted and should be refilled
+                        file.filled = 0;
+                        file.chunks = 0;
+                        FS_CHUNKS_STORE.with(|r| {
+                            let mut fs_data = r.borrow_mut();
+                            for i in 0..file.chunks {
+                                fs_data.remove(&FileId(change.id, i));
+                            }
+                        });
+                    }
+
+                    file.status = status;
+                    if let Some(name) = change.name {
+                        file.name = name;
+                    }
+                    if let Some(content_type) = change.content_type {
+                        file.content_type = content_type;
+                    }
+                    if change.hash.is_some() {
+                        file.hash = change.hash;
+                    }
+                    if change.custom.is_some() {
+                        file.custom = change.custom;
+                    }
+                    file.updated_at = now_ms;
+
+                    let enable_hash_index = state::with(|s| s.enable_hash_index);
+                    if enable_hash_index && prev_hash != file.hash {
+                        HASHS.with(|r| {
+                            let mut hm = r.borrow_mut();
+                            if let Some(ref hash) = file.hash {
+                                if let Some(prev) = hm.get(hash) {
+                                    Err(format!("file hash conflict, {}", prev))?;
+                                }
+                                hm.insert(*hash, change.id);
+                            }
+                            if let Some(prev_hash) = prev_hash {
+                                hm.remove(&prev_hash);
+                            }
+                            Ok::<(), String>(())
+                        })?;
+                    }
+                    m.insert(change.id, file);
+                    Ok(())
+                }
+            }
+        })
+    }
+
+    pub fn get_chunk(id: u32, chunk_index: u32) -> Option<FileChunk> {
+        FS_CHUNKS_STORE.with(|r| {
+            r.borrow()
+                .get(&FileId(id, chunk_index))
+                .map(|v| FileChunk(chunk_index, ByteBuf::from(v.0)))
+        })
+    }
+
+    pub fn get_chunks(id: u32, chunk_index: u32, max_take: u32) -> Vec<FileChunk> {
+        FS_CHUNKS_STORE.with(|r| {
+            let mut buf: Vec<FileChunk> = Vec::with_capacity(max_take as usize);
+            if max_take > 0 {
+                let mut filled = 0usize;
+                let m = r.borrow();
+                for i in chunk_index..(chunk_index + max_take) {
+                    if let Some(Chunk(chunk)) = m.get(&FileId(id, i)) {
+                        filled += chunk.len();
+                        if filled > MAX_FILE_SIZE_PER_CALL as usize {
+                            break;
+                        }
+
+                        buf.push(FileChunk(i, ByteBuf::from(chunk)));
+                        if filled == MAX_FILE_SIZE_PER_CALL as usize {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            buf
+        })
+    }
+
+    pub fn get_full_chunks(id: u32) -> Result<Vec<u8>, String> {
+        let (size, chunks) = FS_METADATA_STORE.with(|r| match r.borrow().get(&id) {
+            None => Err(format!("file not found: {}", id)),
+            Some(file) => {
+                if file.size != file.filled {
+                    Err("file not fully uploaded".to_string())?;
+                }
+                Ok((file.size, file.chunks))
+            }
+        })?;
+
+        if size > MAX_FILE_SIZE.min(usize::MAX as u64) {
+            Err(format!(
+                "file size exceeds limit: {}",
+                MAX_FILE_SIZE.min(usize::MAX as u64)
+            ))?;
+        }
+
+        FS_CHUNKS_STORE.with(|r| {
+            let mut filled = 0usize;
+            let mut buf = Vec::with_capacity(size as usize);
+            if chunks == 0 {
+                return Ok(buf);
+            }
+
+            let m = r.borrow();
+            for i in 0..chunks {
+                match m.get(&FileId(id, i)) {
+                    None => Err(format!("file chunk not found: {}, {}", id, i))?,
+                    Some(Chunk(chunk)) => {
+                        filled += chunk.len();
+                        buf.extend_from_slice(&chunk);
+                    }
+                }
+            }
+
+            if filled as u64 != size {
+                Err(format!(
+                    "file size mismatch, expected {}, got {}",
+                    size, filled
+                ))?;
+            }
+            Ok(buf)
+        })
+    }
+
+    pub fn update_chunk(
+        file_id: u32,
+        chunk_index: u32,
+        now_ms: u64,
+        chunk: Vec<u8>,
+        checker: impl FnOnce(&FileMetadata) -> Result<(), String>,
+    ) -> Result<u64, String> {
+        if chunk.is_empty() {
+            Err("empty chunk".to_string())?;
+        }
+
+        if chunk.len() > CHUNK_SIZE as usize {
+            Err(format!(
+                "chunk size too large, max size is {} bytes",
+                CHUNK_SIZE
+            ))?;
+        }
+
+        let max = state::with(|s| s.max_file_size);
+        FS_METADATA_STORE.with(|r| {
+            let mut m = r.borrow_mut();
+            match m.get(&file_id) {
+                None => Err(format!("file not found: {}", file_id)),
+                Some(mut file) => {
+                    if file.status != 0 {
+                        Err(format!("file {} is not writable", file_id))?;
+                    }
+
+                    checker(&file)?;
+                    file.updated_at = now_ms;
+                    file.filled += chunk.len() as u64;
+                    if file.filled > max {
+                        Err(format!("file size exceeds limit: {}", max))?;
+                    }
+
+                    match FS_CHUNKS_STORE.with(|r| {
+                        r.borrow_mut()
+                            .insert(FileId(file_id, chunk_index), Chunk(chunk))
+                    }) {
+                        None => {}
+                        Some(old) => {
+                            if chunk_index < file.chunks {
+                                file.filled = file.filled.saturating_sub(old.0.len() as u64);
+                            }
+                        }
+                    }
+
+                    if file.chunks <= chunk_index {
+                        file.chunks = chunk_index + 1;
+                    }
+
+                    let filled = file.filled;
+                    if file.size > 0 && filled > file.size {
+                        Err(format!(
+                            "file size mismatch, expected {}, got {}",
+                            file.size, filled
+                        ))?;
+                    }
+
+                    m.insert(file_id, file);
+                    Ok(filled)
+                }
+            }
+        })
+    }
+
+    pub fn delete_folder(
+        id: u32,
+        now_ms: u64,
+        checker: impl FnOnce(&FolderMetadata) -> Result<(), String>,
+    ) -> Result<bool, String> {
+        if id == 0 {
+            Err("root folder cannot be deleted".to_string())?;
+        }
+
+        FOLDERS.with(|r| {
+            let mut folders = r.borrow_mut();
+            let folder = folders.parent_to_update(id)?;
+            let files = folder.files.clone();
+            checker(folder)?;
+
+            FS_METADATA_STORE.with(|r| {
+                let mut fs_metadata = r.borrow_mut();
+
+                FS_CHUNKS_STORE.with(|r| {
+                    let mut fs_data = r.borrow_mut();
+                    for id in files {
+                        match fs_metadata.get(&id) {
+                            Some(file) => {
+                                if file.status < 1 && fs_metadata.remove(&id).is_some() {
+                                    folder.files.remove(&id);
+                                    if let Some(hash) = file.hash {
+                                        HASHS.with(|r| r.borrow_mut().remove(&hash));
+                                    }
+
+                                    for i in 0..file.chunks {
+                                        fs_data.remove(&FileId(id, i));
+                                    }
+                                }
+                            }
+                            None => {
+                                folder.files.remove(&id);
+                            }
+                        }
+                    }
+                });
+            });
+            folders.delete_folder(id, now_ms)
+        })
+    }
+
+    pub fn delete_file(
+        id: u32,
+        now_ms: u64,
+        checker: impl FnOnce(&FileMetadata) -> Result<(), String>,
+    ) -> Result<bool, String> {
+        FS_METADATA_STORE.with(|r| {
+            let mut m = r.borrow_mut();
+            match m.get(&id) {
+                Some(file) => {
+                    if file.status > 0 {
+                        Err("file is readonly".to_string())?;
+                    }
+
+                    checker(&file)?;
+
+                    FOLDERS.with(|r| {
+                        let mut m = r.borrow_mut();
+                        let parent = m.parent_to_update(file.parent)?;
+                        parent.files.remove(&id);
+                        parent.updated_at = now_ms;
+                        Ok::<(), String>(())
+                    })?;
+
+                    m.remove(&id);
+                    if let Some(hash) = file.hash {
+                        HASHS.with(|r| r.borrow_mut().remove(&hash));
+                    }
+                    FS_CHUNKS_STORE.with(|r| {
+                        let mut fs_data = r.borrow_mut();
+                        for i in 0..file.chunks {
+                            fs_data.remove(&FileId(id, i));
+                        }
+                    });
+                    Ok(true)
+                }
+                None => Ok(false),
+            }
+        })
+    }
+
+    pub fn batch_delete_subfiles(
+        parent: u32,
+        ids: BTreeSet<u32>,
+        now_ms: u64,
+    ) -> Result<Vec<u32>, String> {
+        FOLDERS.with(|r| {
+            let mut folders = r.borrow_mut();
+            let folder = folders.parent_to_update(parent)?;
+
+            FS_METADATA_STORE.with(|r| {
+                let mut fs_metadata = r.borrow_mut();
+                let mut removed = Vec::with_capacity(ids.len());
+
+                FS_CHUNKS_STORE.with(|r| {
+                    let mut fs_data = r.borrow_mut();
+                    for id in ids {
+                        if folder.files.contains(&id) {
+                            match fs_metadata.get(&id) {
+                                Some(file) => {
+                                    if file.status < 1 && fs_metadata.remove(&id).is_some() {
+                                        removed.push(id);
+                                        folder.files.remove(&id);
+                                        if let Some(hash) = file.hash {
+                                            HASHS.with(|r| r.borrow_mut().remove(&hash));
+                                        }
+
+                                        for i in 0..file.chunks {
+                                            fs_data.remove(&FileId(id, i));
+                                        }
+                                    }
+                                }
+                                None => {
+                                    folder.files.remove(&id);
+                                }
+                            }
+                        }
+                    }
+                });
+
+                if !removed.is_empty() {
+                    folder.updated_at = now_ms;
+                }
+                Ok(removed)
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_bound_max_size() {
+        let v = FileId(u32::MAX, u32::MAX);
+        let v = v.to_bytes();
+        println!("FileId max_size: {:?}, {}", v.len(), hex::encode(&v));
+
+        let v = FileId(0u32, 0u32);
+        let v = v.to_bytes();
+        println!("FileId min_size: {:?}, {}", v.len(), hex::encode(&v));
+    }
+
+    #[test]
+    fn test_role() {
+        assert!(Role::Manager > Role::Auditor);
+        assert!(Role::Auditor > Role::User);
+    }
+
+    #[test]
+    fn test_fs() {
+        state::with_mut(|b| {
+            b.enable_hash_index = true;
+        });
+
+        assert!(fs::get_file(0).is_none());
+        assert!(fs::get_full_chunks(0).is_err());
+        assert!(fs::get_full_chunks(1).is_err());
+
+        let f1 = fs::add_file(FileMetadata {
+            name: "f1.bin".to_string(),
+            hash: Some(ByteArray::from([1u8; 32])),
+            size: 0,
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(f1, 0);
+
+        let f1_data = fs::get_full_chunks(f1).unwrap();
+        assert!(f1_data.is_empty());
+
+        let f1_meta = fs::get_file(f1).unwrap();
+        assert_eq!(f1_meta.name, "f1.bin");
+
+        let _ = fs::update_chunk(f1, 0, 999, [0u8; 32].to_vec(), |_| Ok(())).unwrap();
+        let _ = fs::update_chunk(f1, 1, 1000, [0u8; 32].to_vec(), |_| Ok(())).unwrap();
+        let res = fs::get_full_chunks(f1);
+        assert!(res.is_err());
+        fs::update_file(
+            UpdateFileInput {
+                id: f1,
+                size: Some(64),
+                ..Default::default()
+            },
+            1000,
+            |_| Ok(()),
+        )
+        .unwrap();
+        let f1_data = fs::get_full_chunks(f1).unwrap();
+        assert_eq!(f1_data, [0u8; 64]);
+
+        let f1_meta = fs::get_file(f1).unwrap();
+        assert_eq!(f1_meta.name, "f1.bin");
+        assert_eq!(f1_meta.size, 64);
+        assert_eq!(f1_meta.filled, 64);
+        assert_eq!(f1_meta.chunks, 2);
+
+        assert!(fs::add_file(FileMetadata {
+            name: "f2.bin".to_string(),
+            hash: Some(ByteArray::from([1u8; 32])),
+            ..Default::default()
+        })
+        .is_err());
+
+        let f2 = fs::add_file(FileMetadata {
+            name: "f2.bin".to_string(),
+            hash: Some(ByteArray::from([2u8; 32])),
+            size: 48,
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(f2, 1);
+        fs::update_chunk(f2, 0, 999, [0u8; 16].to_vec(), |_| Ok(())).unwrap();
+        fs::update_chunk(f2, 1, 1000, [1u8; 16].to_vec(), |_| Ok(())).unwrap();
+
+        fs::update_file(
+            UpdateFileInput {
+                id: f1,
+                size: Some(96),
+                ..Default::default()
+            },
+            1000,
+            |_| Ok(()),
+        )
+        .unwrap();
+        fs::update_chunk(f1, 3, 1000, [1u8; 16].to_vec(), |_| Ok(())).unwrap();
+        fs::update_chunk(f2, 2, 1000, [2u8; 16].to_vec(), |_| Ok(())).unwrap();
+        fs::update_chunk(f1, 2, 1000, [2u8; 16].to_vec(), |_| Ok(())).unwrap();
+
+        let f1_data = fs::get_full_chunks(f1).unwrap();
+        assert_eq!(&f1_data[0..64], &[0u8; 64]);
+        assert_eq!(&f1_data[64..80], &[2u8; 16]);
+        assert_eq!(&f1_data[80..96], &[1u8; 16]);
+
+        let f1_meta = fs::get_file(f1).unwrap();
+        assert_eq!(f1_meta.size, 96);
+        assert_eq!(f1_meta.filled, 96);
+        assert_eq!(f1_meta.chunks, 4);
+
+        let f2_data = fs::get_full_chunks(f2).unwrap();
+        assert_eq!(&f2_data[0..16], &[0u8; 16]);
+        assert_eq!(&f2_data[16..32], &[1u8; 16]);
+        assert_eq!(&f2_data[32..48], &[2u8; 16]);
+
+        let f2_meta = fs::get_file(f2).unwrap();
+        assert_eq!(f2_meta.size, 48);
+        assert_eq!(f2_meta.filled, 48);
+        assert_eq!(f2_meta.chunks, 3);
+
+        // folders
+        let ctx = Context {
+            caller: Principal::anonymous(),
+            ps: Policies::default(),
+            role: Role::Manager,
+        };
+
+        assert_eq!(
+            fs::list_folders(&ctx, 0, 999, 999)
+                .into_iter()
+                .map(|v| v.id)
+                .collect::<Vec<_>>(),
+            Vec::<u32>::new()
+        );
+
+        assert_eq!(
+            fs::list_files(&ctx, 0, 999, 999)
+                .into_iter()
+                .map(|v| v.id)
+                .collect::<Vec<_>>(),
+            vec![f2, f1]
+        );
+
+        assert_eq!(
+            fs::add_folder(FolderMetadata {
+                parent: 0,
+                name: "fd1".to_string(),
+                ..Default::default()
+            })
+            .unwrap(),
+            1
+        );
+
+        assert_eq!(
+            fs::add_folder(FolderMetadata {
+                parent: 0,
+                name: "fd2".to_string(),
+                ..Default::default()
+            })
+            .unwrap(),
+            2
+        );
+
+        assert_eq!(
+            fs::list_folders(&ctx, 0, 999, 999)
+                .into_iter()
+                .map(|v| v.id)
+                .collect::<Vec<_>>(),
+            vec![2, 1]
+        );
+
+        fs::move_file(f1, 0, 1, 1000).unwrap();
+        assert_eq!(
+            fs::get_file_ancestors(f1),
+            vec![FolderName {
+                id: 1,
+                name: "fd1".to_string(),
+            }]
+        );
+        assert_eq!(
+            fs::list_files(&ctx, 0, 999, 999)
+                .into_iter()
+                .map(|v| v.id)
+                .collect::<Vec<_>>(),
+            vec![f2]
+        );
+        assert_eq!(
+            fs::list_files(&ctx, 1, 999, 999)
+                .into_iter()
+                .map(|v| v.id)
+                .collect::<Vec<_>>(),
+            vec![f1]
+        );
+
+        fs::move_file(f2, 0, 2, 1000).unwrap();
+        assert_eq!(
+            fs::get_file_ancestors(f2),
+            vec![FolderName {
+                id: 2,
+                name: "fd2".to_string(),
+            }]
+        );
+        assert_eq!(
+            fs::list_files(&ctx, 0, 999, 999)
+                .into_iter()
+                .map(|v| v.id)
+                .collect::<Vec<_>>(),
+            Vec::<u32>::new()
+        );
+        assert_eq!(
+            fs::list_files(&ctx, 2, 999, 999)
+                .into_iter()
+                .map(|v| v.id)
+                .collect::<Vec<_>>(),
+            vec![f2]
+        );
+
+        fs::move_folder(2, 0, 1, 1000).unwrap();
+        assert_eq!(
+            fs::get_folder_ancestors(2),
+            vec![FolderName {
+                id: 1,
+                name: "fd1".to_string(),
+            }]
+        );
+        assert_eq!(
+            fs::get_file_ancestors(f2),
+            vec![
+                FolderName {
+                    id: 2,
+                    name: "fd2".to_string(),
+                },
+                FolderName {
+                    id: 1,
+                    name: "fd1".to_string(),
+                }
+            ]
+        );
+
+        assert_eq!(
+            fs::batch_delete_subfiles(0, BTreeSet::from([f1, f2]), 999).unwrap(),
+            Vec::<u32>::new()
+        );
+
+        fs::move_file(f1, 1, 0, 1000).unwrap();
+        fs::move_file(f2, 2, 0, 1000).unwrap();
+        assert_eq!(
+            fs::batch_delete_subfiles(0, BTreeSet::from([f2, f1]), 999).unwrap(),
+            vec![f1, f2]
+        );
+        assert!(fs::delete_folder(1, 999, |_| Ok(())).is_err());
+        assert!(fs::delete_folder(2, 999, |_| Ok(())).unwrap());
+        assert!(fs::delete_folder(1, 999, |_| Ok(())).unwrap());
+        assert!(fs::delete_folder(0, 999, |_| Ok(())).is_err());
+
+        assert_eq!(FOLDERS.with(|r| r.borrow().len()), 1);
+        assert_eq!(HASHS.with(|r| r.borrow().len()), 0);
+        assert_eq!(FS_METADATA_STORE.with(|r| r.borrow().len()), 0);
+        assert_eq!(FS_CHUNKS_STORE.with(|r| r.borrow().len()), 0);
+    }
+
+    #[test]
+    fn test_folders_tree_depth() {
+        let mut tree = FoldersTree::new();
+        tree.add_folder(
+            FolderMetadata {
+                parent: 0,
+                name: "fd1".to_string(),
+                ..Default::default()
+            },
+            1,
+            10,
+            1000,
+        )
+        .unwrap();
+        tree.add_folder(
+            FolderMetadata {
+                parent: 1,
+                name: "fd2".to_string(),
+                ..Default::default()
+            },
+            2,
+            10,
+            1000,
+        )
+        .unwrap();
+        tree.add_folder(
+            FolderMetadata {
+                parent: 2,
+                name: "fd3".to_string(),
+                ..Default::default()
+            },
+            3,
+            10,
+            1000,
+        )
+        .unwrap();
+        assert_eq!(tree.depth(0), 0);
+        assert_eq!(tree.depth(1), 1);
+        assert_eq!(tree.depth(3), 3);
+        assert_eq!(tree.depth(99), 0);
+
+        assert_eq!(tree.depth_or_is_ancestor(2, 0), (2, true));
+        assert_eq!(tree.depth_or_is_ancestor(2, 1), (1, true));
+        assert_eq!(tree.depth_or_is_ancestor(2, 2), (0, true));
+        assert_eq!(tree.depth_or_is_ancestor(2, 3), (2, false));
+        assert_eq!(tree.depth_or_is_ancestor(99, 0), (0, true));
+        assert_eq!(tree.depth_or_is_ancestor(99, 1), (0, false));
+
+        assert_eq!(tree.ancestors(0), Vec::<FolderName>::new());
+        assert_eq!(
+            tree.ancestors(1),
+            vec![FolderName {
+                id: 1,
+                name: "fd1".to_string(),
+            }]
+        );
+        assert_eq!(
+            tree.ancestors(2),
+            vec![
+                FolderName {
+                    id: 2,
+                    name: "fd2".to_string(),
+                },
+                FolderName {
+                    id: 1,
+                    name: "fd1".to_string(),
+                }
+            ]
+        );
+        assert_eq!(tree.ancestors(99), Vec::<FolderName>::new());
+    }
+
+    #[test]
+    fn test_folders_tree_list_folders() {
+        let mut tree = FoldersTree::new();
+        tree.add_folder(
+            FolderMetadata {
+                parent: 0,
+                name: "fd1".to_string(),
+                ..Default::default()
+            },
+            1,
+            10,
+            1000,
+        )
+        .unwrap();
+        tree.add_folder(
+            FolderMetadata {
+                parent: 1,
+                name: "fd2".to_string(),
+                ..Default::default()
+            },
+            2,
+            10,
+            1000,
+        )
+        .unwrap();
+        tree.add_folder(
+            FolderMetadata {
+                parent: 1,
+                name: "fd3".to_string(),
+                ..Default::default()
+            },
+            3,
+            10,
+            1000,
+        )
+        .unwrap();
+
+        let ctx = Context {
+            caller: Principal::anonymous(),
+            ps: Policies::default(),
+            role: Role::Manager,
+        };
+
+        assert_eq!(
+            tree.list_folders(&ctx, 0, 999, 999)
+                .into_iter()
+                .map(|v| v.id)
+                .collect::<Vec<_>>(),
+            vec![1]
+        );
+        assert_eq!(
+            tree.list_folders(&ctx, 1, 999, 999)
+                .into_iter()
+                .map(|v| v.id)
+                .collect::<Vec<_>>(),
+            vec![3, 2]
+        );
+        assert_eq!(
+            tree.list_folders(&ctx, 99, 999, 999)
+                .into_iter()
+                .map(|v| v.id)
+                .collect::<Vec<_>>(),
+            Vec::<u32>::new()
+        );
+    }
+
+    #[test]
+    fn test_folders_tree_add_folder() {
+        let mut tree = FoldersTree::new();
+        assert!(tree
+            .add_folder(
+                FolderMetadata {
+                    parent: 1,
+                    name: "fd1".to_string(),
+                    ..Default::default()
+                },
+                1,
+                10,
+                1000,
+            )
+            .err()
+            .unwrap()
+            .contains("parent folder not found"));
+        assert!(tree
+            .add_folder(
+                FolderMetadata {
+                    parent: 0,
+                    name: "fd1".to_string(),
+                    ..Default::default()
+                },
+                1,
+                1,
+                1,
+            )
+            .is_ok());
+        assert!(tree
+            .add_folder(
+                FolderMetadata {
+                    parent: 0,
+                    name: "fd2".to_string(),
+                    ..Default::default()
+                },
+                1,
+                1,
+                1,
+            )
+            .err()
+            .unwrap()
+            .contains("folder id already exists"));
+        assert!(tree
+            .add_folder(
+                FolderMetadata {
+                    parent: 1,
+                    name: "fd2".to_string(),
+                    ..Default::default()
+                },
+                2,
+                1,
+                1,
+            )
+            .err()
+            .unwrap()
+            .contains("folder depth exceeds limit"));
+        assert!(tree
+            .add_folder(
+                FolderMetadata {
+                    parent: 0,
+                    name: "fd2".to_string(),
+                    ..Default::default()
+                },
+                2,
+                1,
+                1,
+            )
+            .is_ok());
+        assert!(tree
+            .add_folder(
+                FolderMetadata {
+                    parent: 1,
+                    name: "fd2".to_string(),
+                    ..Default::default()
+                },
+                3,
+                2,
+                1,
+            )
+            .is_ok());
+        assert!(tree
+            .add_folder(
+                FolderMetadata {
+                    parent: 1,
+                    name: "fd2".to_string(),
+                    ..Default::default()
+                },
+                4,
+                2,
+                1,
+            )
+            .err()
+            .unwrap()
+            .contains("children exceeds limit"));
+        tree.get_mut(&0).unwrap().status = 1;
+        assert!(tree
+            .add_folder(
+                FolderMetadata {
+                    parent: 0,
+                    name: "fd2".to_string(),
+                    ..Default::default()
+                },
+                4,
+                1,
+                2,
+            )
+            .err()
+            .unwrap()
+            .contains("parent folder is not writable"));
+        tree.get_mut(&0).unwrap().status = 0;
+        assert!(tree
+            .add_folder(
+                FolderMetadata {
+                    parent: 0,
+                    name: "fd2".to_string(),
+                    ..Default::default()
+                },
+                4,
+                1,
+                2,
+            )
+            .is_ok());
+    }
+
+    #[test]
+    fn test_folders_tree_parent_to_add_file() {
+        let mut tree = FoldersTree::new();
+        assert!(tree
+            .parent_to_add_file(1, 2)
+            .err()
+            .unwrap()
+            .contains("parent folder not found"));
+        tree.get_mut(&0).unwrap().status = 1;
+        assert!(tree
+            .parent_to_add_file(0, 2)
+            .err()
+            .unwrap()
+            .contains("parent folder is not writable"));
+        tree.get_mut(&0).unwrap().status = 0;
+        assert!(tree.parent_to_add_file(0, 2).is_ok());
+    }
+
+    #[test]
+    fn test_folders_tree_move_folder() {
+        let mut tree = FoldersTree::new();
+        assert!(tree
+            .check_moving_folder(0, 1, 2, 10, 100)
+            .err()
+            .unwrap()
+            .contains("root folder cannot be moved"));
+        assert!(tree
+            .check_moving_folder(1, 2, 2, 10, 100)
+            .err()
+            .unwrap()
+            .contains("target parent folder should not be 2"));
+        assert!(tree
+            .check_moving_folder(1, 0, 2, 10, 100)
+            .err()
+            .unwrap()
+            .contains("folder not found"));
+        tree.add_folder(
+            FolderMetadata {
+                parent: 0,
+                name: "fd1".to_string(),
+                ..Default::default()
+            },
+            1,
+            10,
+            100,
+        )
+        .unwrap();
+        assert!(tree
+            .check_moving_folder(1, 2, 0, 10, 100)
+            .err()
+            .unwrap()
+            .contains("is not in folder"));
+        tree.get_mut(&1).unwrap().status = 1;
+        assert!(tree
+            .check_moving_folder(1, 0, 2, 10, 100)
+            .err()
+            .unwrap()
+            .contains("is not writable"));
+
+        tree.get_mut(&1).unwrap().status = 0;
+        tree.get_mut(&0).unwrap().status = 1;
+        assert!(tree
+            .check_moving_folder(1, 0, 2, 10, 100)
+            .err()
+            .unwrap()
+            .contains("is not writable"));
+        tree.get_mut(&0).unwrap().status = 0;
+        assert!(tree
+            .check_moving_folder(1, 0, 2, 10, 100)
+            .err()
+            .unwrap()
+            .contains("folder not found"));
+
+        tree.add_folder(
+            FolderMetadata {
+                parent: 0,
+                status: 1,
+                name: "fd2".to_string(),
+                ..Default::default()
+            },
+            2,
+            10,
+            100,
+        )
+        .unwrap();
+        assert!(tree
+            .check_moving_folder(1, 0, 2, 10, 100)
+            .err()
+            .unwrap()
+            .contains("is not writable"));
+        tree.get_mut(&2).unwrap().status = 0;
+        assert!(tree
+            .check_moving_folder(1, 0, 2, 10, 0)
+            .err()
+            .unwrap()
+            .contains("children exceeds limit"));
+        assert!(tree
+            .check_moving_folder(1, 0, 2, 0, 100)
+            .err()
+            .unwrap()
+            .contains("folder depth exceeds limit"));
+        assert!(tree.check_moving_folder(1, 0, 2, 10, 100).is_ok());
+        assert_eq!(tree.get_mut(&0).unwrap().folders, BTreeSet::from([1, 2]));
+        assert_eq!(tree.get_mut(&2).unwrap().folders, BTreeSet::from([]));
+        tree.move_folder(1, 0, 2, 999);
+        assert_eq!(tree.get_mut(&0).unwrap().folders, BTreeSet::from([2]));
+        assert_eq!(tree.get_mut(&2).unwrap().folders, BTreeSet::from([1]));
+        assert!(tree
+            .check_moving_folder(2, 0, 1, 10, 100)
+            .err()
+            .unwrap()
+            .contains("folder cannot be moved to its sub folder"));
+    }
+
+    #[test]
+    fn test_folders_tree_move_file() {
+        let mut tree = FoldersTree::new();
+        assert!(tree
+            .check_moving_file(1, 1, 100)
+            .err()
+            .unwrap()
+            .contains("target parent should not be"));
+        assert!(tree
+            .check_moving_file(1, 0, 100)
+            .err()
+            .unwrap()
+            .contains("folder not found"));
+        tree.get_mut(&0).unwrap().status = 1;
+        assert!(tree
+            .check_moving_file(0, 1, 100)
+            .err()
+            .unwrap()
+            .contains("is not writable"));
+        tree.get_mut(&0).unwrap().status = 0;
+        assert!(tree
+            .check_moving_file(0, 1, 100)
+            .err()
+            .unwrap()
+            .contains("folder not found"));
+        tree.add_folder(
+            FolderMetadata {
+                parent: 0,
+                status: 1,
+                name: "fd1".to_string(),
+                ..Default::default()
+            },
+            1,
+            10,
+            100,
+        )
+        .unwrap();
+        assert!(tree
+            .check_moving_file(0, 1, 100)
+            .err()
+            .unwrap()
+            .contains("is not writable"));
+        tree.get_mut(&1).unwrap().status = 0;
+        assert!(tree
+            .check_moving_file(0, 1, 0)
+            .err()
+            .unwrap()
+            .contains("children exceeds limit"));
+        assert!(tree.check_moving_file(0, 1, 10).is_ok());
+        tree.move_file(1, 0, 1, 999);
+        assert_eq!(tree.get_mut(&1).unwrap().files, BTreeSet::from([1]));
+        tree.move_file(1, 1, 0, 999);
+        assert_eq!(tree.get_mut(&0).unwrap().files, BTreeSet::from([1]));
+        assert_eq!(tree.get_mut(&1).unwrap().files, BTreeSet::new());
+    }
+
+    #[test]
+    fn test_folders_delete_folder() {
+        let mut tree = FoldersTree::new();
+        assert!(tree
+            .delete_folder(0, 99)
+            .err()
+            .unwrap()
+            .contains("root folder cannot be deleted"));
+        assert!(!tree.delete_folder(1, 99).unwrap());
+        tree.add_folder(
+            FolderMetadata {
+                parent: 0,
+                status: 1,
+                name: "fd1".to_string(),
+                files: BTreeSet::from([1]),
+                ..Default::default()
+            },
+            1,
+            10,
+            100,
+        )
+        .unwrap();
+        assert!(tree
+            .delete_folder(1, 99)
+            .err()
+            .unwrap()
+            .contains("folder is readonly"));
+        tree.get_mut(&1).unwrap().status = 0;
+        assert!(tree
+            .delete_folder(1, 99)
+            .err()
+            .unwrap()
+            .contains("folder is not empty"));
+        tree.get_mut(&1).unwrap().files.clear();
+        tree.get_mut(&0).unwrap().status = 1;
+        assert!(tree
+            .delete_folder(1, 99)
+            .err()
+            .unwrap()
+            .contains("parent folder is not writable"));
+        tree.get_mut(&0).unwrap().status = 0;
+        assert!(tree.delete_folder(1, 99).unwrap());
+        assert_eq!(tree.len(), 1);
+        assert_eq!(tree.get_mut(&0).unwrap().folders, BTreeSet::new());
+        assert_eq!(tree.get_mut(&0).unwrap().updated_at, 99);
+    }
+}
+
+// api_update.rs
+use ic_oss_types::{file::*, folder::*, to_cbor_bytes};
+use serde_bytes::ByteBuf;
+use std::collections::BTreeSet;
+
+use crate::{permission, store, MILLISECONDS, SECONDS};
+
+#[ic_cdk::update]
+fn create_file(
+    input: CreateFileInput,
+    access_token: Option<ByteBuf>,
+) -> Result<CreateFileOutput, String> {
+    input.validate()?;
+
+    let size = input.size.unwrap_or(0);
+    store::state::with(|s| {
+        if size > s.max_file_size {
+            return Err(format!("file size exceeds the limit {}", s.max_file_size));
+        }
+        if let Some(ref custom) = input.custom {
+            let len = to_cbor_bytes(custom).len();
+            if len > s.max_custom_data_size as usize {
+                return Err(format!(
+                    "custom data size exceeds the limit {}",
+                    s.max_custom_data_size
+                ));
+            }
+        }
+        Ok(())
+    })?;
+
+    let now_ms = ic_cdk::api::time() / MILLISECONDS;
+    let canister = ic_cdk::id();
+    let ctx = match store::state::with(|s| {
+        s.write_permission(ic_cdk::caller(), &canister, access_token, now_ms / 1000)
+    }) {
+        Ok(ctx) => ctx,
+        Err((_, err)) => {
+            return Err(err);
+        }
+    };
+
+    if !permission::check_file_create(&ctx.ps, &canister, input.parent) {
+        Err("permission denied".to_string())?;
+    }
+
+    let res: Result<CreateFileOutput, String> = {
+        let id = store::fs::add_file(store::FileMetadata {
+            parent: input.parent,
+            name: input.name,
+            content_type: input.content_type,
+            size,
+            hash: input.hash,
+            dek: input.dek,
+            custom: input.custom,
+            created_at: now_ms,
+            updated_at: now_ms,
+            ..Default::default()
+        })?;
+
+        if let Some(content) = input.content {
+            if size > 0 && content.len() != size as usize {
+                Err("content size mismatch".to_string())?;
+            }
+
+            for (i, chunk) in content.chunks(CHUNK_SIZE as usize).enumerate() {
+                store::fs::update_chunk(id, i as u32, now_ms, chunk.to_vec(), |_| Ok(()))?;
+            }
+
+            if input.status.is_some() {
+                store::fs::update_file(
+                    UpdateFileInput {
+                        id,
+                        status: input.status,
+                        ..Default::default()
+                    },
+                    now_ms,
+                    |_| Ok(()),
+                )?;
+            }
+        }
+
+        Ok(CreateFileOutput {
+            id,
+            created_at: now_ms,
+        })
+    };
+
+    match res {
+        Ok(output) => Ok(output),
+        Err(err) => {
+            // trap and rollback state
+            ic_cdk::trap(&format!("create file failed: {}", err));
+        }
+    }
+}
+
+#[ic_cdk::update]
+fn update_file_info(
+    input: UpdateFileInput,
+    access_token: Option<ByteBuf>,
+) -> Result<UpdateFileOutput, String> {
+    input.validate()?;
+
+    store::state::with(|s| {
+        if input.size.unwrap_or_default() > s.max_file_size {
+            return Err(format!("file size exceeds the limit {}", s.max_file_size));
+        }
+
+        if let Some(ref custom) = input.custom {
+            let len = to_cbor_bytes(custom).len();
+            if len > s.max_custom_data_size as usize {
+                return Err(format!(
+                    "custom data size exceeds the limit {}",
+                    s.max_custom_data_size
+                ));
+            }
+        }
+        Ok(())
+    })?;
+
+    let now_ms = ic_cdk::api::time() / MILLISECONDS;
+    let canister = ic_cdk::id();
+    let ctx = match store::state::with(|s| {
+        s.write_permission(ic_cdk::caller(), &canister, access_token, now_ms / 1000)
+    }) {
+        Ok(ctx) => ctx,
+        Err((_, err)) => {
+            return Err(err);
+        }
+    };
+
+    let id = input.id;
+    let res = store::fs::update_file(input, now_ms, |file| {
+        match permission::check_file_update(&ctx.ps, &canister, id, file.parent) {
+            true => Ok(()),
+            false => Err("permission denied".to_string()),
+        }
+    });
+
+    match res {
+        Ok(_) => Ok(UpdateFileOutput { updated_at: now_ms }),
+        Err(err) => {
+            // trap and rollback state
+            ic_cdk::trap(&format!("update file info failed: {}", err));
+        }
+    }
+}
+
+#[ic_cdk::update]
+fn update_file_chunk(
+    input: UpdateFileChunkInput,
+    access_token: Option<ByteBuf>,
+) -> Result<UpdateFileChunkOutput, String> {
+    let now_ms = ic_cdk::api::time() / MILLISECONDS;
+    let canister = ic_cdk::id();
+    let ctx = match store::state::with(|s| {
+        s.write_permission(
+            ic_cdk::caller(),
+            &canister,
+            access_token,
+            ic_cdk::api::time() / SECONDS,
+        )
+    }) {
+        Ok(ctx) => ctx,
+        Err((_, err)) => {
+            return Err(err);
+        }
+    };
+
+    let id = input.id;
+    let res = store::fs::update_chunk(
+        input.id,
+        input.chunk_index,
+        now_ms,
+        input.content.into_vec(),
+        |file| match permission::check_file_update(&ctx.ps, &canister, id, file.parent) {
+            true => Ok(()),
+            false => Err("permission denied".to_string()),
+        },
+    );
+
+    match res {
+        Ok(filled) => Ok(UpdateFileChunkOutput {
+            filled,
+            updated_at: now_ms,
+        }),
+        Err(err) => {
+            // trap and rollback state
+            ic_cdk::trap(&format!("update file chunk failed: {}", err));
+        }
+    }
+}
+
+#[ic_cdk::update]
+fn move_file(input: MoveInput, access_token: Option<ByteBuf>) -> Result<UpdateFileOutput, String> {
+    let now_ms = ic_cdk::api::time() / MILLISECONDS;
+    let canister = ic_cdk::id();
+    let ctx = match store::state::with(|s| {
+        s.write_permission(ic_cdk::caller(), &canister, access_token, now_ms / 1000)
+    }) {
+        Ok(ctx) => ctx,
+        Err((_, err)) => {
+            return Err(err);
+        }
+    };
+
+    if !permission::check_file_delete(&ctx.ps, &canister, input.from) {
+        Err("permission denied".to_string())?;
+    }
+
+    if !permission::check_file_create(&ctx.ps, &canister, input.to) {
+        Err("permission denied".to_string())?;
+    }
+
+    store::fs::move_file(input.id, input.from, input.to, now_ms)?;
+    Ok(UpdateFileOutput { updated_at: now_ms })
+}
+
+#[ic_cdk::update]
+fn delete_file(id: u32, access_token: Option<ByteBuf>) -> Result<bool, String> {
+    let now_ms = ic_cdk::api::time() / MILLISECONDS;
+    let canister = ic_cdk::id();
+    let ctx = match store::state::with(|s| {
+        s.write_permission(ic_cdk::caller(), &canister, access_token, now_ms / 1000)
+    }) {
+        Ok(ctx) => ctx,
+        Err((_, err)) => {
+            return Err(err);
+        }
+    };
+
+    store::fs::delete_file(id, now_ms, |file| {
+        match permission::check_file_delete(&ctx.ps, &canister, file.parent) {
+            true => Ok(()),
+            false => Err("permission denied".to_string()),
+        }
+    })
+}
+
+#[ic_cdk::update]
+fn batch_delete_subfiles(
+    parent: u32,
+    ids: BTreeSet<u32>,
+    access_token: Option<ByteBuf>,
+) -> Result<Vec<u32>, String> {
+    let now_ms = ic_cdk::api::time() / MILLISECONDS;
+    let canister = ic_cdk::id();
+    let ctx = match store::state::with(|s| {
+        s.write_permission(ic_cdk::caller(), &canister, access_token, now_ms / 1000)
+    }) {
+        Ok(ctx) => ctx,
+        Err((_, err)) => {
+            return Err(err);
+        }
+    };
+
+    if !permission::check_file_delete(&ctx.ps, &canister, parent) {
+        Err("permission denied".to_string())?;
+    }
+
+    store::fs::batch_delete_subfiles(parent, ids, now_ms)
+}
+
+#[ic_cdk::update]
+fn create_folder(
+    input: CreateFolderInput,
+    access_token: Option<ByteBuf>,
+) -> Result<CreateFolderOutput, String> {
+    input.validate()?;
+    let now_ms = ic_cdk::api::time() / MILLISECONDS;
+    let canister = ic_cdk::id();
+    let ctx = match store::state::with(|s| {
+        s.write_permission(ic_cdk::caller(), &canister, access_token, now_ms / 1000)
+    }) {
+        Ok(ctx) => ctx,
+        Err((_, err)) => {
+            return Err(err);
+        }
+    };
+
+    if !permission::check_folder_create(&ctx.ps, &canister, input.parent) {
+        Err("permission denied".to_string())?;
+    }
+
+    let res: Result<CreateFolderOutput, String> = {
+        let id = store::fs::add_folder(store::FolderMetadata {
+            parent: input.parent,
+            name: input.name,
+            created_at: now_ms,
+            updated_at: now_ms,
+            ..Default::default()
+        })?;
+
+        Ok(CreateFolderOutput {
+            id,
+            created_at: now_ms,
+        })
+    };
+
+    match res {
+        Ok(output) => Ok(output),
+        Err(err) => {
+            // trap and rollback state
+            ic_cdk::trap(&format!("create file failed: {}", err));
+        }
+    }
+}
+
+#[ic_cdk::update]
+fn update_folder_info(
+    input: UpdateFolderInput,
+    access_token: Option<ByteBuf>,
+) -> Result<UpdateFolderOutput, String> {
+    input.validate()?;
+
+    let now_ms = ic_cdk::api::time() / MILLISECONDS;
+    let canister = ic_cdk::id();
+    let ctx = match store::state::with(|s| {
+        s.write_permission(ic_cdk::caller(), &canister, access_token, now_ms / 1000)
+    }) {
+        Ok(ctx) => ctx,
+        Err((_, err)) => {
+            return Err(err);
+        }
+    };
+
+    let id = input.id;
+    store::fs::update_folder(
+        input,
+        now_ms,
+        |folder| match permission::check_folder_update(&ctx.ps, &canister, id, folder.parent) {
+            true => Ok(()),
+            false => Err("permission denied".to_string()),
+        },
+    )?;
+
+    Ok(UpdateFolderOutput { updated_at: now_ms })
+}
+
+#[ic_cdk::update]
+fn move_folder(
+    input: MoveInput,
+    access_token: Option<ByteBuf>,
+) -> Result<UpdateFolderOutput, String> {
+    let now_ms = ic_cdk::api::time() / MILLISECONDS;
+    let canister = ic_cdk::id();
+    let ctx = match store::state::with(|s| {
+        s.write_permission(ic_cdk::caller(), &canister, access_token, now_ms / 1000)
+    }) {
+        Ok(ctx) => ctx,
+        Err((_, err)) => {
+            return Err(err);
+        }
+    };
+
+    if !permission::check_folder_delete(&ctx.ps, &canister, input.from) {
+        Err("permission denied".to_string())?;
+    }
+
+    if !permission::check_folder_create(&ctx.ps, &canister, input.to) {
+        Err("permission denied".to_string())?;
+    }
+
+    store::fs::move_folder(input.id, input.from, input.to, now_ms)?;
+    Ok(UpdateFolderOutput { updated_at: now_ms })
+}
+
+#[ic_cdk::update]
+fn delete_folder(id: u32, access_token: Option<ByteBuf>) -> Result<bool, String> {
+    let now_ms = ic_cdk::api::time() / MILLISECONDS;
+    let canister = ic_cdk::id();
+    let ctx = match store::state::with(|s| {
+        s.write_permission(ic_cdk::caller(), &canister, access_token, now_ms / 1000)
+    }) {
+        Ok(ctx) => ctx,
+        Err((_, err)) => {
+            return Err(err);
+        }
+    };
+
+    store::fs::delete_folder(id, now_ms, |folder| {
+        match permission::check_folder_delete(&ctx.ps, &canister, folder.parent) {
+            true => Ok(()),
+            false => Err("permission denied".to_string()),
+        }
+    })
+}
+
+// api_query.rs
+use ic_cdk::api::management_canister::main::{
+    canister_status, CanisterIdRecord, CanisterStatusResponse,
+};
+use ic_oss_types::{
+    bucket::BucketInfo,
+    file::{FileChunk, FileInfo},
+    folder::{FolderInfo, FolderName},
+    format_error,
+};
+use serde_bytes::{ByteArray, ByteBuf};
+
+use crate::{permission, store, SECONDS};
+
+#[ic_cdk::query]
+fn api_version() -> u16 {
+    1
+}
+
+#[ic_cdk::query]
+fn get_bucket_info(_access_token: Option<ByteBuf>) -> Result<BucketInfo, String> {
+    // let canister = ic_cdk::id();
+    // let ctx = match store::state::with(|s| {
+    //     s.read_permission(
+    //         ic_cdk::caller(),
+    //         &canister,
+    //         access_token,
+    //         ic_cdk::api::time() / SECONDS,
+    //     )
+    // }) {
+    //     Ok(ctx) => ctx,
+    //     Err((_, err)) => {
+    //         return Err(err);
+    //     }
+    // };
+
+    // if !permission::check_bucket_read(&ctx.ps, &canister) {
+    //     return Err("permission denied".to_string());
+    // }
+
+    Ok(store::state::with(|r| BucketInfo {
+        name: r.name.clone(),
+        file_id: r.file_id,
+        folder_id: r.folder_id,
+        max_file_size: r.max_file_size,
+        max_folder_depth: r.max_folder_depth,
+        max_children: r.max_children,
+        max_custom_data_size: r.max_custom_data_size,
+        enable_hash_index: r.enable_hash_index,
+        status: r.status,
+        visibility: r.visibility,
+        total_files: store::fs::total_files(),
+        total_chunks: store::fs::total_chunks(),
+        total_folders: store::fs::total_folders(),
+        managers: r.managers.clone(),
+        auditors: r.auditors.clone(),
+        trusted_ecdsa_pub_keys: r.trusted_ecdsa_pub_keys.clone(),
+        trusted_eddsa_pub_keys: r.trusted_eddsa_pub_keys.clone(),
+        governance_canister: r.governance_canister,
+    }))
+}
+
+#[ic_cdk::update]
+async fn get_canister_status() -> Result<CanisterStatusResponse, String> {
+    let canister = ic_cdk::id();
+    let ctx = match store::state::with(|s| {
+        s.read_permission(
+            ic_cdk::caller(),
+            &canister,
+            None,
+            ic_cdk::api::time() / SECONDS,
+        )
+    }) {
+        Ok(ctx) => ctx,
+        Err((_, err)) => {
+            return Err(err);
+        }
+    };
+
+    if !permission::check_bucket_read(&ctx.ps, &canister) {
+        return Err("permission denied".to_string());
+    }
+
+    let (res,) = canister_status(CanisterIdRecord {
+        canister_id: ic_cdk::id(),
+    })
+    .await
+    .map_err(format_error)?;
+    Ok(res)
+}
+
+#[ic_cdk::query]
+fn get_file_info(id: u32, access_token: Option<ByteBuf>) -> Result<FileInfo, String> {
+    match store::fs::get_file(id) {
+        None => Err("file not found".to_string()),
+        Some(file) => {
+            if !file.read_by_hash(&access_token) {
+                let canister = ic_cdk::id();
+                let ctx = match store::state::with(|s| {
+                    s.read_permission(
+                        ic_cdk::caller(),
+                        &canister,
+                        access_token,
+                        ic_cdk::api::time() / SECONDS,
+                    )
+                }) {
+                    Ok(ctx) => ctx,
+                    Err((_, err)) => {
+                        return Err(err);
+                    }
+                };
+
+                if !permission::check_file_read(&ctx.ps, &canister, id, file.parent) {
+                    Err("permission denied".to_string())?;
+                }
+            }
+
+            Ok(file.into_info(id))
+        }
+    }
+}
+
+#[ic_cdk::query]
+fn get_file_info_by_hash(
+    hash: ByteArray<32>,
+    access_token: Option<ByteBuf>,
+) -> Result<FileInfo, String> {
+    let id = store::fs::get_file_id(&hash).ok_or("file not found")?;
+
+    get_file_info(id, access_token)
+}
+
+#[ic_cdk::query]
+fn get_file_ancestors(id: u32, access_token: Option<ByteBuf>) -> Result<Vec<FolderName>, String> {
+    let ancestors = store::fs::get_file_ancestors(id);
+    if let Some(parent) = ancestors.first() {
+        let canister = ic_cdk::id();
+        let ctx = match store::state::with(|s| {
+            s.read_permission(
+                ic_cdk::caller(),
+                &canister,
+                access_token,
+                ic_cdk::api::time() / SECONDS,
+            )
+        }) {
+            Ok(ctx) => ctx,
+            Err((_, err)) => {
+                return Err(err);
+            }
+        };
+
+        if !permission::check_file_read(&ctx.ps, &canister, id, parent.id) {
+            Err("permission denied".to_string())?;
+        }
+    }
+    Ok(ancestors)
+}
+
+#[ic_cdk::query]
+fn get_file_chunks(
+    id: u32,
+    index: u32,
+    take: Option<u32>,
+    access_token: Option<ByteBuf>,
+) -> Result<Vec<FileChunk>, String> {
+    match store::fs::get_file(id) {
+        None => Err("file not found".to_string()),
+        Some(file) => {
+            if !file.read_by_hash(&access_token) {
+                let canister = ic_cdk::id();
+                let ctx = match store::state::with(|s| {
+                    s.read_permission(
+                        ic_cdk::caller(),
+                        &canister,
+                        access_token,
+                        ic_cdk::api::time() / SECONDS,
+                    )
+                }) {
+                    Ok(ctx) => ctx,
+                    Err((_, err)) => {
+                        return Err(err);
+                    }
+                };
+
+                if file.status < 0 && ctx.role < store::Role::Auditor {
+                    Err("file archived".to_string())?;
+                }
+
+                if !permission::check_file_read(&ctx.ps, &canister, id, file.parent) {
+                    Err("permission denied".to_string())?;
+                }
+            }
+
+            Ok(store::fs::get_chunks(id, index, take.unwrap_or(8).min(8)))
+        }
+    }
+}
+
+#[ic_cdk::query]
+fn list_files(
+    parent: u32,
+    prev: Option<u32>,
+    take: Option<u32>,
+    access_token: Option<ByteBuf>,
+) -> Result<Vec<FileInfo>, String> {
+    let prev = prev.unwrap_or(u32::MAX);
+    let take = take.unwrap_or(10).min(100);
+    let canister = ic_cdk::id();
+    let ctx = match store::state::with(|s| {
+        s.read_permission(
+            ic_cdk::caller(),
+            &canister,
+            access_token,
+            ic_cdk::api::time() / SECONDS,
+        )
+    }) {
+        Ok(ctx) => ctx,
+        Err((_, err)) => {
+            return Err(err);
+        }
+    };
+
+    if !permission::check_file_list(&ctx.ps, &canister, parent) {
+        Err("permission denied".to_string())?;
+    }
+    Ok(store::fs::list_files(&ctx, parent, prev, take))
+}
+
+#[ic_cdk::query]
+fn get_folder_info(id: u32, access_token: Option<ByteBuf>) -> Result<FolderInfo, String> {
+    match store::fs::get_folder(id) {
+        None => Err("folder not found".to_string()),
+        Some(meta) => {
+            let canister = ic_cdk::id();
+            let ctx = match store::state::with(|s| {
+                s.read_permission(
+                    ic_cdk::caller(),
+                    &canister,
+                    access_token,
+                    ic_cdk::api::time() / SECONDS,
+                )
+            }) {
+                Ok(ctx) => ctx,
+                Err((_, err)) => {
+                    return Err(err);
+                }
+            };
+
+            if !permission::check_folder_read(&ctx.ps, &canister, id) {
+                Err("permission denied".to_string())?;
+            }
+
+            Ok(meta.into_info(id))
+        }
+    }
+}
+
+#[ic_cdk::query]
+fn get_folder_ancestors(id: u32, access_token: Option<ByteBuf>) -> Result<Vec<FolderName>, String> {
+    let ancestors = store::fs::get_folder_ancestors(id);
+    if !ancestors.is_empty() {
+        let canister = ic_cdk::id();
+        let ctx = match store::state::with(|s| {
+            s.read_permission(
+                ic_cdk::caller(),
+                &canister,
+                access_token,
+                ic_cdk::api::time() / SECONDS,
+            )
+        }) {
+            Ok(ctx) => ctx,
+            Err((_, err)) => {
+                return Err(err);
+            }
+        };
+
+        if !permission::check_folder_read(&ctx.ps, &canister, id) {
+            Err("permission denied".to_string())?;
+        }
+    }
+    Ok(ancestors)
+}
+
+#[ic_cdk::query]
+fn list_folders(
+    parent: u32,
+    prev: Option<u32>,
+    take: Option<u32>,
+    access_token: Option<ByteBuf>,
+) -> Result<Vec<FolderInfo>, String> {
+    let prev = prev.unwrap_or(u32::MAX);
+    let take = take.unwrap_or(10).min(100);
+
+    let canister = ic_cdk::id();
+    let ctx = match store::state::with(|s| {
+        s.read_permission(
+            ic_cdk::caller(),
+            &canister,
+            access_token,
+            ic_cdk::api::time() / SECONDS,
+        )
+    }) {
+        Ok(ctx) => ctx,
+        Err((_, err)) => {
+            return Err(err);
+        }
+    };
+
+    if !permission::check_folder_list(&ctx.ps, &canister, parent) {
+        Err("permission denied".to_string())?;
+    }
+    Ok(store::fs::list_folders(&ctx, parent, prev, take))
+}
+
+// lib.rs
+
+use candid::Principal;
+use ic_cdk::api::management_canister::main::CanisterStatusResponse;
+use serde_bytes::{ByteArray, ByteBuf};
+use std::collections::BTreeSet;
+
+mod api_admin;
+mod api_http;
+mod api_init;
+mod api_query;
+mod api_update;
+mod permission;
+mod store;
+
+use api_init::CanisterArgs;
+use ic_oss_types::{bucket::*, file::*, folder::*};
+
+const MILLISECONDS: u64 = 1_000_000;
+const SECONDS: u64 = 1_000_000_000;
+
+static ANONYMOUS: Principal = Principal::anonymous();
+
+fn is_controller() -> Result<(), String> {
+    let caller = ic_cdk::caller();
+    if ic_cdk::api::is_controller(&caller) || store::state::is_controller(&caller) {
+        Ok(())
+    } else {
+        Err("user is not a controller".to_string())
+    }
+}
+
+pub fn validate_principals(principals: &BTreeSet<Principal>) -> Result<(), String> {
+    if principals.is_empty() {
+        return Err("principals cannot be empty".to_string());
+    }
+    if principals.contains(&ANONYMOUS) {
+        return Err("anonymous user is not allowed".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(all(
+    target_arch = "wasm32",
+    target_vendor = "unknown",
+    target_os = "unknown"
+))]
+/// A getrandom implementation that always fails
+pub fn always_fail(_buf: &mut [u8]) -> Result<(), getrandom::Error> {
+    Err(getrandom::Error::UNSUPPORTED)
+}
+
+#[cfg(all(
+    target_arch = "wasm32",
+    target_vendor = "unknown",
+    target_os = "unknown"
+))]
+getrandom::register_custom_getrandom!(always_fail);
+
+ic_cdk::export_candid!();
+
+
+
+// api_http.rs
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use candid::{define_function, CandidType};
+use hyperx::header::{Charset, ContentDisposition, DispositionParam, DispositionType};
+use hyperx::header::{ContentRangeSpec, Header, IfRange, Range, Raw};
+use ic_http_certification::{HeaderField, HttpRequest};
+use ic_oss_types::{
+    file::{UrlFileParam, CHUNK_SIZE, MAX_FILE_SIZE_PER_CALL},
+    to_cbor_bytes,
+};
+use ic_stable_structures::Storable;
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use serde_bytes::ByteBuf;
+use std::path::Path;
+use std::str::FromStr;
+
+use crate::{permission, store, SECONDS};
+
+#[derive(CandidType, Deserialize, Clone, Default)]
+pub struct HttpStreamingResponse {
+    pub status_code: u16,
+    pub headers: Vec<HeaderField>,
+    pub body: ByteBuf,
+    pub upgrade: Option<bool>,
+    pub streaming_strategy: Option<StreamingStrategy>,
+}
+
+#[derive(CandidType, Deserialize, Clone)]
+pub struct StreamingCallbackToken {
+    pub id: u32,
+    pub chunk_index: u32,
+    pub chunks: u32,
+    pub token: Option<ByteBuf>,
+}
+
+impl StreamingCallbackToken {
+    pub fn next(self) -> Option<StreamingCallbackToken> {
+        if self.chunk_index + 1 >= self.chunks {
+            None
+        } else {
+            Some(StreamingCallbackToken {
+                id: self.id,
+                chunk_index: self.chunk_index + 1,
+                chunks: self.chunks,
+                token: self.token,
+            })
+        }
+    }
+}
+
+define_function!(pub CallbackFunc : (StreamingCallbackToken) -> (StreamingCallbackHttpResponse) query);
+
+#[derive(CandidType, Deserialize, Clone)]
+pub enum StreamingStrategy {
+    Callback {
+        token: StreamingCallbackToken,
+        callback: CallbackFunc,
+    },
+}
+
+#[derive(CandidType, Deserialize, Clone)]
+pub struct StreamingCallbackHttpResponse {
+    pub body: ByteBuf,
+    pub token: Option<StreamingCallbackToken>,
+}
+
+static STREAMING_CALLBACK: Lazy<CallbackFunc> =
+    Lazy::new(|| CallbackFunc::new(ic_cdk::id(), "http_request_streaming_callback".to_string()));
+
+fn create_strategy(arg: StreamingCallbackToken) -> Option<StreamingStrategy> {
+    arg.next().map(|token| StreamingStrategy::Callback {
+        token,
+        callback: STREAMING_CALLBACK.clone(),
+    })
+}
+
+static OCTET_STREAM: &str = "application/octet-stream";
+static IC_CERTIFICATE_HEADER: &str = "ic-certificate";
+static IC_CERTIFICATE_EXPRESSION_HEADER: &str = "ic-certificateexpression";
+
+// request url example:
+// https://mmrxu-fqaaa-aaaap-ahhna-cai.icp0.io/f/1
+// http://mmrxu-fqaaa-aaaap-ahhna-cai.localhost:4943/f/1 // download file by id 1
+// http://mmrxu-fqaaa-aaaap-ahhna-cai.localhost:4943/h/8546ffa4296a6960e9e64e95de178d40c231a0cd358a65477bc56a105dda1c1d //download file by hash 854...
+#[ic_cdk::query(hidden = true)]
+fn http_request(request: HttpRequest) -> HttpStreamingResponse {
+    let witness = store::state::http_tree_with(|t| {
+        t.witness(&store::state::DEFAULT_CERT_ENTRY, request.url())
+            .expect("get witness failed")
+    });
+    let certified_data = ic_cdk::api::data_certificate().expect("no data certificate available");
+    let mut headers = vec![
+        ("content-type".to_string(), "text/plain".to_string()),
+        ("x-content-type-options".to_string(), "nosniff".to_string()),
+        (
+            IC_CERTIFICATE_EXPRESSION_HEADER.to_string(),
+            store::state::DEFAULT_CEL_EXPR.clone(),
+        ),
+        (
+            IC_CERTIFICATE_HEADER.to_string(),
+            format!(
+                "certificate=:{}:, tree=:{}:, expr_path=:{}:, version=2",
+                BASE64.encode(certified_data),
+                BASE64.encode(to_cbor_bytes(&witness)),
+                BASE64.encode(to_cbor_bytes(
+                    &store::state::DEFAULT_EXPR_PATH.to_expr_path()
+                ))
+            ),
+        ),
+    ];
+
+    match UrlFileParam::from_url(request.url()) {
+        Err(err) => HttpStreamingResponse {
+            status_code: 400,
+            headers,
+            body: ByteBuf::from(err.as_bytes()),
+            ..Default::default()
+        },
+        Ok(param) => {
+            let id = if let Some(hash) = param.hash {
+                store::fs::get_file_id(&hash).unwrap_or_default()
+            } else {
+                param.file
+            };
+
+            match store::fs::get_file(id) {
+                None => HttpStreamingResponse {
+                    status_code: 404,
+                    headers,
+                    body: ByteBuf::from("file not found".as_bytes()),
+                    ..Default::default()
+                },
+                Some(file) => {
+                    if !file.read_by_hash(&param.token) {
+                        let canister = ic_cdk::id();
+                        let ctx = match store::state::with(|s| {
+                            s.read_permission(
+                                ic_cdk::caller(),
+                                &canister,
+                                param.token,
+                                ic_cdk::api::time() / SECONDS,
+                            )
+                        }) {
+                            Ok(ctx) => ctx,
+                            Err((status_code, err)) => {
+                                return HttpStreamingResponse {
+                                    status_code,
+                                    headers,
+                                    body: ByteBuf::from(err.as_bytes()),
+                                    ..Default::default()
+                                };
+                            }
+                        };
+
+                        if file.status < 0 && ctx.role < store::Role::Auditor {
+                            return HttpStreamingResponse {
+                                status_code: 403,
+                                headers,
+                                body: ByteBuf::from("file archived".as_bytes()),
+                                ..Default::default()
+                            };
+                        }
+
+                        if !permission::check_file_read(&ctx.ps, &canister, id, file.parent) {
+                            return HttpStreamingResponse {
+                                status_code: 403,
+                                headers,
+                                body: ByteBuf::from("permission denied".as_bytes()),
+                                ..Default::default()
+                            };
+                        }
+                    }
+
+                    if file.size != file.filled {
+                        return HttpStreamingResponse {
+                            status_code: 422,
+                            headers,
+                            body: ByteBuf::from("file not fully uploaded".as_bytes()),
+                            ..Default::default()
+                        };
+                    }
+
+                    let etag = file
+                        .hash
+                        .as_ref()
+                        .map(|hash| BASE64.encode(hash.as_ref()))
+                        .unwrap_or_default();
+
+                    headers.push(("accept-ranges".to_string(), "bytes".to_string()));
+                    if !etag.is_empty() {
+                        headers.push(("etag".to_string(), format!("\"{}\"", etag)));
+                    }
+                    headers[0].1 = if file.content_type.is_empty() {
+                        OCTET_STREAM.to_string()
+                    } else {
+                        file.content_type.clone()
+                    };
+
+                    if request.method() == "HEAD" {
+                        headers.push(("content-length".to_string(), file.size.to_string()));
+                        headers.push((
+                            "cache-control".to_string(),
+                            "max-age=2592000, public".to_string(),
+                        ));
+
+                        let filename = if param.inline {
+                            ""
+                        } else if let Some(ref name) = param.name {
+                            name
+                        } else {
+                            &file.name
+                        };
+
+                        headers.push((
+                            "content-disposition".to_string(),
+                            content_disposition(filename),
+                        ));
+
+                        return HttpStreamingResponse {
+                            status_code: 200,
+                            headers,
+                            body: ByteBuf::new(),
+                            ..Default::default()
+                        };
+                    }
+
+                    if let Some(range_req) = detect_range(request.headers(), file.size, &etag) {
+                        match range_req {
+                            Err(err) => {
+                                return HttpStreamingResponse {
+                                    status_code: 416,
+                                    headers,
+                                    body: ByteBuf::from(err.to_bytes()),
+                                    ..Default::default()
+                                };
+                            }
+                            Ok(range) => {
+                                return range_response(headers, id, file, range);
+                            }
+                        }
+                    }
+
+                    let filename = if param.inline {
+                        ""
+                    } else if let Some(ref name) = param.name {
+                        name
+                    } else {
+                        &file.name
+                    };
+
+                    headers.push((
+                        "content-disposition".to_string(),
+                        content_disposition(filename),
+                    ));
+
+                    // return all chunks for small file
+                    let (chunk_index, body) = if file.size <= MAX_FILE_SIZE_PER_CALL {
+                        (
+                            file.chunks.saturating_sub(1),
+                            store::fs::get_full_chunks(id)
+                                .map(ByteBuf::from)
+                                .unwrap_or_default(),
+                        )
+                    } else {
+                        // return first chunk for large file
+                        (
+                            0,
+                            store::fs::get_chunk(id, 0)
+                                .map(|chunk| chunk.1)
+                                .unwrap_or_default(),
+                        )
+                    };
+
+                    let streaming_strategy = create_strategy(StreamingCallbackToken {
+                        id,
+                        chunk_index,
+                        chunks: file.chunks,
+                        token: None, // TODO: access token for callback
+                    });
+
+                    // small file
+                    if streaming_strategy.is_none() {
+                        headers.push(("content-length".to_string(), body.len().to_string()));
+                        headers.push((
+                            "cache-control".to_string(),
+                            "max-age=2592000, public".to_string(),
+                        ));
+                    }
+
+                    HttpStreamingResponse {
+                        status_code: 200,
+                        headers,
+                        body,
+                        streaming_strategy,
+                        upgrade: None,
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[ic_cdk::query(hidden = true)]
+fn http_request_streaming_callback(token: StreamingCallbackToken) -> StreamingCallbackHttpResponse {
+    match store::fs::get_chunk(token.id, token.chunk_index) {
+        None => ic_cdk::trap("chunk not found"),
+        Some(chunk) => StreamingCallbackHttpResponse {
+            body: chunk.1,
+            token: token.next(),
+        },
+    }
+}
+
+fn detect_range(
+    headers: &[(String, String)],
+    full_length: u64,
+    etag: &str,
+) -> Option<Result<(u64, u64), String>> {
+    let range = headers.iter().find_map(|(name, value)| {
+        if name.to_lowercase() == "range" {
+            Some(Range::from_str(value))
+        } else {
+            None
+        }
+    });
+
+    match range {
+        None => None,
+        Some(Err(err)) => Some(Err(err.to_string())),
+        Some(Ok(Range::Unregistered(_, _))) => {
+            Some(Err("invalid range, custom range not support".to_string()))
+        }
+        Some(Ok(Range::Bytes(brs))) => {
+            if brs.len() != 1 {
+                return Some(Err(
+                    "invalid range, multiple byte ranges not support".to_string()
+                ));
+            }
+
+            let mut range = match brs[0].to_satisfiable_range(full_length) {
+                None => return Some(Err("invalid range, out of range".to_string())),
+                Some(range) => range,
+            };
+
+            if range.1 + 1 - range.0 > MAX_FILE_SIZE_PER_CALL {
+                range = (range.0, range.0 + MAX_FILE_SIZE_PER_CALL - 1);
+            }
+
+            let if_range = headers.iter().find_map(|(name, value)| {
+                if name.to_lowercase() == "if-range" {
+                    Some(IfRange::parse_header(&Raw::from(value.as_str())))
+                } else {
+                    None
+                }
+            });
+
+            match if_range {
+                None => Some(Ok(range)),
+                Some(Err(err)) => Some(Err(err.to_string())),
+                Some(Ok(IfRange::Date(_))) => Some(Err(
+                    "invalid if-range value, date value not support".to_string(),
+                )),
+                Some(Ok(IfRange::EntityTag(tag))) => {
+                    if tag.tag() == etag {
+                        Some(Ok(range))
+                    } else {
+                        Some(Err("invalid if-range value, etag not match".to_string()))
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn range_response(
+    mut headers: Vec<(String, String)>,
+    id: u32,
+    metadata: store::FileMetadata,
+    (start, end): (u64, u64),
+) -> HttpStreamingResponse {
+    let chunk_index = start / CHUNK_SIZE as u64;
+    let chunk_offset = (start % CHUNK_SIZE as u64) as usize;
+    let chunk_end = end / CHUNK_SIZE as u64;
+    let end_offset = (end % CHUNK_SIZE as u64) as usize;
+
+    let mut body = ByteBuf::with_capacity((end + 1 - start) as usize);
+    for i in chunk_index..=chunk_end {
+        let chunk = store::fs::get_chunk(id, i as u32)
+            .map(|chunk| chunk.1)
+            .unwrap_or_default();
+        let start = if i == chunk_index { chunk_offset } else { 0 };
+        let end = if i == chunk_end {
+            end_offset
+        } else {
+            CHUNK_SIZE as usize - 1
+        };
+
+        if end >= chunk.len() {
+            return HttpStreamingResponse {
+                status_code: 416,
+                headers,
+                body: ByteBuf::from(format!("invalid range at chunk {i}").to_bytes()),
+                ..Default::default()
+            };
+        }
+
+        body.extend_from_slice(&chunk[start..=end]);
+    }
+
+    headers[0].1 = if metadata.content_type.is_empty() {
+        OCTET_STREAM.to_string()
+    } else {
+        metadata.content_type.clone()
+    };
+    headers.push((
+        "content-disposition".to_string(),
+        content_disposition(&metadata.name),
+    ));
+    headers.push(("content-length".to_string(), body.len().to_string()));
+    headers.push((
+        "content-range".to_string(),
+        ContentRangeSpec::Bytes {
+            range: Some((start, end)),
+            instance_length: Some(metadata.size),
+        }
+        .to_string(),
+    ));
+
+    HttpStreamingResponse {
+        status_code: 206,
+        headers,
+        body,
+        upgrade: None,
+        streaming_strategy: None,
+    }
+}
+
+fn content_disposition(filename: &str) -> String {
+    if filename.is_empty() {
+        return ContentDisposition {
+            disposition: DispositionType::Inline,
+            parameters: vec![],
+        }
+        .to_string();
+    }
+
+    let filename = Path::new(filename)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(filename);
+
+    ContentDisposition {
+        disposition: DispositionType::Attachment,
+        parameters: vec![DispositionParam::Filename(
+            Charset::Ext("UTF-8".to_owned()),
+            None,
+            filename.as_bytes().to_vec(),
+        )],
+    }
+    .to_string()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_content_disposition() {
+        assert_eq!(content_disposition(""), "inline");
+        assert_eq!(
+            content_disposition("统计数据.txt"),
+            "attachment; filename*=UTF-8''%E7%BB%9F%E8%AE%A1%E6%95%B0%E6%8D%AE.txt",
+        );
+        assert_eq!(
+            content_disposition("/统计数据.txt"),
+            "attachment; filename*=UTF-8''%E7%BB%9F%E8%AE%A1%E6%95%B0%E6%8D%AE.txt",
+        );
+        assert_eq!(
+            content_disposition("./test.txt"),
+            "attachment; filename=\"test.txt\"",
+        );
+    }
+}
+
+// api_admin.rs
+
+use candid::Principal;
+use ic_oss_types::bucket::UpdateBucketInput;
+use std::collections::BTreeSet;
+
+use crate::{is_controller, store, validate_principals};
+
+#[ic_cdk::update(guard = "is_controller")]
+fn admin_set_managers(args: BTreeSet<Principal>) -> Result<(), String> {
+    validate_admin_set_managers(args.clone())?;
+    store::state::with_mut(|r| {
+        r.managers = args;
+    });
+    Ok(())
+}
+
+#[ic_cdk::update(guard = "is_controller")]
+fn admin_add_managers(mut args: BTreeSet<Principal>) -> Result<(), String> {
+    validate_principals(&args)?;
+    store::state::with_mut(|r| {
+        r.managers.append(&mut args);
+        Ok(())
+    })
+}
+
+#[ic_cdk::update(guard = "is_controller")]
+fn admin_remove_managers(args: BTreeSet<Principal>) -> Result<(), String> {
+    validate_principals(&args)?;
+    store::state::with_mut(|r| {
+        r.managers.retain(|p| !args.contains(p));
+        Ok(())
+    })
+}
+
+#[ic_cdk::update(guard = "is_controller")]
+fn admin_add_auditors(mut args: BTreeSet<Principal>) -> Result<(), String> {
+    validate_principals(&args)?;
+    store::state::with_mut(|r| {
+        r.auditors.append(&mut args);
+        Ok(())
+    })
+}
+
+#[ic_cdk::update(guard = "is_controller")]
+fn admin_remove_auditors(args: BTreeSet<Principal>) -> Result<(), String> {
+    validate_principals(&args)?;
+    store::state::with_mut(|r| {
+        r.auditors.retain(|p| !args.contains(p));
+        Ok(())
+    })
+}
+
+#[ic_cdk::update(guard = "is_controller")]
+fn admin_set_auditors(args: BTreeSet<Principal>) -> Result<(), String> {
+    validate_principals(&args)?;
+    store::state::with_mut(|r| {
+        r.auditors = args;
+    });
+    Ok(())
+}
+
+#[ic_cdk::update(guard = "is_controller")]
+fn admin_update_bucket(args: UpdateBucketInput) -> Result<(), String> {
+    args.validate()?;
+    store::state::with_mut(|s| {
+        if let Some(name) = args.name {
+            s.name = name;
+        }
+        if let Some(max_file_size) = args.max_file_size {
+            s.max_file_size = max_file_size;
+        }
+        if let Some(max_folder_depth) = args.max_folder_depth {
+            s.max_folder_depth = max_folder_depth;
+        }
+        if let Some(max_children) = args.max_children {
+            s.max_children = max_children;
+        }
+        if let Some(max_custom_data_size) = args.max_custom_data_size {
+            s.max_custom_data_size = max_custom_data_size;
+        }
+        if let Some(enable_hash_index) = args.enable_hash_index {
+            s.enable_hash_index = enable_hash_index;
+        }
+        if let Some(status) = args.status {
+            s.status = status;
+        }
+        if let Some(visibility) = args.visibility {
+            s.visibility = visibility;
+        }
+        if let Some(trusted_ecdsa_pub_keys) = args.trusted_ecdsa_pub_keys {
+            s.trusted_ecdsa_pub_keys = trusted_ecdsa_pub_keys;
+        }
+        if let Some(trusted_eddsa_pub_keys) = args.trusted_eddsa_pub_keys {
+            s.trusted_eddsa_pub_keys = trusted_eddsa_pub_keys;
+        }
+    });
+    Ok(())
+}
+
+// ----- Use validate2_xxxxxx instead of validate_xxxxxx -----
+
+#[ic_cdk::update]
+fn validate_admin_set_managers(args: BTreeSet<Principal>) -> Result<(), String> {
+    validate_principals(&args)?;
+    Ok(())
+}
+
+#[ic_cdk::update]
+fn validate2_admin_set_managers(args: BTreeSet<Principal>) -> Result<String, String> {
+    validate_principals(&args)?;
+    Ok("ok".to_string())
+}
+
+#[ic_cdk::update]
+fn validate_admin_set_auditors(args: BTreeSet<Principal>) -> Result<(), String> {
+    validate_principals(&args)?;
+    Ok(())
+}
+
+#[ic_cdk::update]
+fn validate2_admin_set_auditors(args: BTreeSet<Principal>) -> Result<String, String> {
+    validate_principals(&args)?;
+    Ok("ok".to_string())
+}
+
+#[ic_cdk::update]
+fn validate_admin_update_bucket(args: UpdateBucketInput) -> Result<(), String> {
+    args.validate()
+}
+
+#[ic_cdk::update]
+fn validate2_admin_update_bucket(args: UpdateBucketInput) -> Result<String, String> {
+    args.validate()?;
+    Ok("ok".to_string())
+}
+
+#[ic_cdk::update]
+fn validate_admin_add_managers(args: BTreeSet<Principal>) -> Result<String, String> {
+    validate_principals(&args)?;
+    Ok("ok".to_string())
+}
+
+#[ic_cdk::update]
+fn validate_admin_remove_managers(args: BTreeSet<Principal>) -> Result<String, String> {
+    validate_principals(&args)?;
+    Ok("ok".to_string())
+}
+
+#[ic_cdk::update]
+fn validate_admin_add_auditors(args: BTreeSet<Principal>) -> Result<String, String> {
+    validate_principals(&args)?;
+    Ok("ok".to_string())
+}
+
+#[ic_cdk::update]
+fn validate_admin_remove_auditors(args: BTreeSet<Principal>) -> Result<String, String> {
+    validate_principals(&args)?;
+    Ok("ok".to_string())
+}
+
+// ic_oss_types/src/file.rs
+use base64::{engine::general_purpose, Engine};
+use candid::CandidType;
+use serde::{Deserialize, Serialize};
+use serde_bytes::{ByteArray, ByteBuf};
+use std::path::Path;
+use url::Url;
+
+use crate::{format_error, MapValue};
+
+pub const CHUNK_SIZE: u32 = 256 * 1024;
+pub const MAX_FILE_SIZE: u64 = 384 * 1024 * 1024 * 1024; // 384GB
+pub const MAX_FILE_SIZE_PER_CALL: u64 = 1024 * 2000; // should less than 2MB
+
+pub static CUSTOM_KEY_BY_HASH: &str = "by_hash";
+
+#[derive(CandidType, Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FileInfo {
+    pub id: u32,
+    pub parent: u32, // 0: root
+    pub name: String,
+    pub content_type: String,
+    pub size: u64,
+    pub filled: u64,
+    pub created_at: u64, // unix timestamp in milliseconds
+    pub updated_at: u64, // unix timestamp in milliseconds
+    pub chunks: u32,
+    pub status: i8, // -1: archived; 0: readable and writable; 1: readonly
+    pub hash: Option<ByteArray<32>>,
+    pub dek: Option<ByteBuf>, // // Data Encryption Key that encrypted by BYOK or vetKey in COSE_Encrypt0
+    pub custom: Option<MapValue>, // custom metadata
+    pub ex: Option<MapValue>, // External Resource info
+}
+
+#[derive(CandidType, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct CreateFileInput {
+    pub parent: u32,
+    pub name: String,
+    pub content_type: String,
+    pub size: Option<u64>, // if provided, can be used to detect the file is fully filled
+    pub content: Option<ByteBuf>, // should <= 1024 * 1024 * 2 - 1024
+    pub status: Option<i8>, // when set to 1, the file must be fully filled, and hash must be provided
+    pub hash: Option<ByteArray<32>>, // recommend sha3 256
+    pub dek: Option<ByteBuf>,
+    pub custom: Option<MapValue>,
+}
+
+pub fn valid_file_name(name: &str) -> bool {
+    if name.is_empty() || name.trim() != name || name.len() > 96 {
+        return false;
+    }
+
+    let p = Path::new(name);
+    p.file_name() == Some(p.as_os_str())
+}
+
+pub fn valid_file_parent(parent: &str) -> bool {
+    if parent.is_empty() || parent == "/" {
+        return true;
+    }
+
+    if !parent.starts_with('/') {
+        return false;
+    }
+
+    for name in parent[1..].split('/') {
+        if !valid_file_name(name) {
+            return false;
+        }
+    }
+    true
+}
+
+impl CreateFileInput {
+    pub fn validate(&self) -> Result<(), String> {
+        if !valid_file_name(&self.name) {
+            return Err("invalid file name".to_string());
+        }
+
+        if self.content_type.is_empty() {
+            return Err("content_type cannot be empty".to_string());
+        }
+
+        if let Some(content) = &self.content {
+            if content.is_empty() {
+                return Err("content cannot be empty".to_string());
+            }
+        }
+
+        if let Some(status) = self.status {
+            if !(0i8..=1i8).contains(&status) {
+                return Err("status should be 0 or 1".to_string());
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(CandidType, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct CreateFileOutput {
+    pub id: u32,
+    pub created_at: u64,
+}
+
+#[derive(CandidType, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct UpdateFileInput {
+    pub id: u32,
+    pub name: Option<String>,
+    pub content_type: Option<String>,
+    pub status: Option<i8>, // when set to 1, the file must be fully filled, and hash must be provided
+    pub size: Option<u64>, // if provided and smaller than file.filled, the file content will be deleted and should be refilled
+    pub hash: Option<ByteArray<32>>,
+    pub custom: Option<MapValue>,
+}
+
+impl UpdateFileInput {
+    pub fn validate(&self) -> Result<(), String> {
+        if let Some(name) = &self.name {
+            if !valid_file_name(name) {
+                return Err("invalid file name".to_string());
+            }
+        }
+        if let Some(content_type) = &self.content_type {
+            if content_type.is_empty() {
+                return Err("content_type cannot be empty".to_string());
+            }
+        }
+        if let Some(status) = self.status {
+            if !(-1i8..=1i8).contains(&status) {
+                return Err("status should be -1, 0 or 1".to_string());
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(CandidType, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct UpdateFileOutput {
+    pub updated_at: u64,
+}
+
+#[derive(CandidType, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct UpdateFileChunkInput {
+    pub id: u32,
+    pub chunk_index: u32,
+    pub content: ByteBuf, // should be in (0, 1024 * 256]
+}
+
+#[derive(CandidType, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct UpdateFileChunkOutput {
+    pub filled: u64,
+    pub updated_at: u64,
+}
+
+#[derive(CandidType, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct FileChunk(pub u32, pub ByteBuf);
+
+#[derive(CandidType, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct MoveInput {
+    pub id: u32,
+    pub from: u32,
+    pub to: u32,
+}
+
+#[derive(Debug)]
+pub struct UrlFileParam {
+    pub file: u32,
+    pub hash: Option<ByteArray<32>>,
+    pub token: Option<ByteBuf>,
+    pub name: Option<String>,
+    pub inline: bool,
+}
+
+impl UrlFileParam {
+    pub fn from_url(req_url: &str) -> Result<Self, String> {
+        let url = if req_url.starts_with('/') {
+            Url::parse(format!("http://localhost{}", req_url).as_str())
+        } else {
+            Url::parse(req_url)
+        };
+        let url = url.map_err(|_| format!("invalid url: {}", req_url))?;
+        let mut path_segments = url
+            .path_segments()
+            .ok_or_else(|| format!("invalid url path: {}", req_url))?;
+
+        let mut param = match path_segments.next() {
+            Some("f") => Self {
+                file: path_segments
+                    .next()
+                    .unwrap_or_default()
+                    .parse()
+                    .map_err(|_| "invalid file id")?,
+                hash: None,
+                token: None,
+                name: None,
+                inline: false,
+            },
+            Some("h") => {
+                let val = path_segments.next().unwrap_or_default();
+                let data = hex::decode(val).map_err(format_error)?;
+                let hash: [u8; 32] = data.try_into().map_err(format_error)?;
+                let hash = ByteArray::from(hash);
+                Self {
+                    file: 0,
+                    hash: Some(hash),
+                    token: None,
+                    name: None,
+                    inline: false,
+                }
+            }
+            _ => return Err(format!("invalid url path: {}", req_url)),
+        };
+
+        for (key, value) in url.query_pairs() {
+            match key.as_ref() {
+                "token" => {
+                    let data = general_purpose::URL_SAFE_NO_PAD
+                        .decode(value.as_bytes())
+                        .map_err(|_| format!("failed to decode base64 token from {}", value))?;
+                    param.token = Some(ByteBuf::from(data));
+                    break;
+                }
+                "filename" => {
+                    param.name = Some(value.to_string());
+                }
+                "inline" => {
+                    param.inline = true;
+                }
+                _ => {}
+            }
+        }
+
+        // use the last path segment as filename if provided
+        if let Some(filename) = path_segments.next() {
+            param.name = Some(filename.to_string());
+        }
+
+        Ok(param)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_file_name_works() {
+        assert!(valid_file_name("file"));
+        assert!(valid_file_name("file.txt"));
+        assert!(valid_file_name(".file.txt"));
+        assert!(valid_file_name("file.txt."));
+        assert!(valid_file_name("..."));
+
+        assert!(!valid_file_name(""));
+        assert!(!valid_file_name("."));
+        assert!(!valid_file_name(".."));
+        assert!(!valid_file_name(" file.txt"));
+        assert!(!valid_file_name("/file.txt"));
+        assert!(!valid_file_name("./file.txt"));
+        assert!(!valid_file_name("test/file.txt"));
+        assert!(!valid_file_name("file.txt/"));
+    }
+
+    #[test]
+    fn valid_file_parent_works() {
+        assert!(valid_file_parent(""));
+        assert!(valid_file_parent("/"));
+        assert!(valid_file_parent("/file"));
+        assert!(valid_file_parent("/file.txt"));
+        assert!(valid_file_parent("/file/.txt"));
+
+        assert!(!valid_file_parent("file.txt"));
+        assert!(!valid_file_parent("//file.txt"));
+        assert!(!valid_file_parent("/./file.txt"));
+        assert!(!valid_file_parent("/../file.txt"));
+        assert!(!valid_file_parent("test/file.txt"));
+        assert!(!valid_file_parent("/file/"));
+    }
+}

--- a/prompts/current-file-upload.prompt.txt
+++ b/prompts/current-file-upload.prompt.txt
@@ -1,0 +1,680 @@
+// current code i want to refactor
+
+// src/cargo.toml
+[package]
+name = "canisters-official-backend"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+ic-cdk-timers = "0.10" # Feel free to remove this dependency if you don't need timers
+candid = "0.10.13"
+ic-cdk = "0.17"
+serde = "1.0.217"
+serde_bytes = "0.11"
+serde_cbor = "0.11"
+serde_json = "1"
+ic-http-certification = "3.0.2"
+lazy_static = "1.5.0"
+matchit = "0.8"
+serde_urlencoded = "0.7.1"
+sha2 = "0.10.8"
+base64 = "0.22.1"
+ic-cdk-macros = "0.17.1"
+hex = "0.4.3"
+regex = "1.10.6"
+ic-stable-structures = "0.6.7"
+ciborium = "0.2.2"
+urlencoding = "2.1.3"
+url = "2.5.4"
+
+
+// src/core/state/raw_storage/state.rs
+use std::cell::RefCell;
+use std::collections::HashMap;
+use crate::core::state::raw_storage::types::{ChunkId, FileChunk};
+
+thread_local! {
+    pub static CHUNKS: RefCell<HashMap<ChunkId, FileChunk>> = RefCell::new(HashMap::new());
+    pub static FILE_CHUNKS: RefCell<HashMap<String, Vec<ChunkId>>> = RefCell::new(HashMap::new());
+    pub static FILE_META: RefCell<HashMap<String, String>> = RefCell::new(HashMap::new());
+}
+
+pub fn store_chunk(chunk: FileChunk) {
+    CHUNKS.with(|chunks| {
+        chunks.borrow_mut().insert(chunk.id.clone(), chunk.clone());
+    });
+
+    FILE_CHUNKS.with(|file_chunks| {
+        let mut map = file_chunks.borrow_mut();
+        map.entry(chunk.file_id.clone())
+           .or_insert_with(Vec::new)
+           .push(chunk.id);
+    });
+}
+
+pub fn get_chunk(chunk_id: &ChunkId) -> Option<FileChunk> {
+    CHUNKS.with(|chunks| chunks.borrow().get(chunk_id).cloned())
+}
+
+pub fn get_file_chunks(file_id: &str) -> Vec<FileChunk> {
+    FILE_CHUNKS.with(|file_chunks| {
+        if let Some(chunk_ids) = file_chunks.borrow().get(file_id) {
+            chunk_ids.iter()
+                    .filter_map(|id| get_chunk(id))
+                    .collect()
+        } else {
+            Vec::new()
+        }
+    })
+}
+
+
+pub fn store_filename(file_id: &str, filename: &str) {
+    FILE_META.with(|fmeta| {
+        fmeta.borrow_mut().insert(file_id.to_string(), filename.to_string());
+    });
+}
+
+// src/core/state/raw_storage/types.rs
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ChunkId(pub String);
+
+impl fmt::Display for ChunkId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileChunk {
+    pub id: ChunkId,
+    pub file_id: String,
+    pub chunk_index: u32,
+    pub data: Vec<u8>,
+    pub size: usize
+}
+
+pub const CHUNK_SIZE: usize = 3 * 1024 * (1024 / 2); // 1.5MB chunks
+
+// src/rest/directorys/types.rs
+use serde::{Deserialize, Serialize};
+use crate::{core::state::directory::types::{FileMetadata, FolderMetadata}, rest::webhooks::types::SortDirection};
+
+#[derive(Debug, Clone, Deserialize)]
+pub enum DirectoryAction {
+    #[serde(rename = "get")]
+    Get,
+    #[serde(rename = "create")]
+    Create,
+    #[serde(rename = "update")]
+    Update,
+    #[serde(rename = "delete")]
+    Delete,
+    #[serde(rename = "copy")]
+    Copy,
+    #[serde(rename = "move")]
+    Move,
+    #[serde(rename = "sync")]
+    Sync,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DirectoryActionRequest {
+    pub action: DirectoryAction,
+    #[serde(flatten)]
+    pub params: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DirectoryActionResponse {
+    #[serde(flatten)]
+    pub data: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SearchDirectoryRequest {
+    pub query_string: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListDirectoryRequest {
+    pub folder_id: Option<String>,
+    pub path: Option<String>,
+    #[serde(default)]
+    pub filters: String,
+    #[serde(default = "default_page_size")]
+    pub page_size: usize,
+    #[serde(default)]
+    pub direction: SortDirection,
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DirectoryListResponse {
+    pub folders: Vec<FolderMetadata>,
+    pub files: Vec<FileMetadata>,
+    pub total_files: usize,
+    pub total_folders: usize,
+    pub cursor: Option<String>,
+}
+
+fn default_page_size() -> usize {
+    50
+}
+
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UploadChunkRequest {
+    pub file_id: String,
+    pub chunk_index: u32,
+    pub chunk_data: Vec<u8>,
+    pub total_chunks: u32
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UploadChunkResponse {
+    pub chunk_id: String,
+    pub bytes_received: usize
+}
+
+#[derive(Debug, Clone, Deserialize)] 
+pub struct CompleteUploadRequest {
+    pub file_id: String,
+    pub filename: String
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CompleteUploadResponse {
+    pub file_id: String,
+    pub size: usize,
+    pub chunks: u32,
+    pub filename: String
+}
+
+
+#[derive(serde::Serialize)]
+pub struct FileMetadataResponse {
+    pub file_id: String,
+    pub total_size: usize,
+    pub total_chunks: u32,
+    pub filename: String
+}
+
+pub type SearchDirectoryResponse = DirectoryListResponse;
+
+pub type DirectoryResponse<'a, T> = crate::rest::drives::types::DriveResponse<'a, T>;
+pub type ErrorResponse<'a> = DirectoryResponse<'a, ()>;
+
+
+// src/rest/directorys/route.rs
+use crate::debug_log;
+use crate::rest::router;
+use crate::types::RouteHandler;
+
+pub const DIRECTORYS_SEARCH_PATH: &str = "/directory/search";
+pub const DIRECTORYS_LIST_PATH: &str = "/directory/list";
+pub const DIRECTORYS_ACTION_PATH: &str = "/directory/action";
+pub const UPLOAD_CHUNK_PATH: &str = "/directory/raw_upload/chunk";
+pub const COMPLETE_UPLOAD_PATH: &str = "/directory/raw_upload/complete";
+pub const RAW_DOWNLOAD_META_PATH: &str = "/directory/raw_download/meta";
+pub const RAW_DOWNLOAD_CHUNK_PATH: &str = "/directory/raw_download/chunk";
+
+type HandlerEntry = (&'static str, &'static str, RouteHandler);
+
+pub fn init_routes() {
+    let routes: &[HandlerEntry] = &[
+        (
+            "POST",
+            DIRECTORYS_SEARCH_PATH,
+            crate::rest::directory::handler::directorys_handlers::search_directory_handler,
+        ),
+        (
+            "POST",
+            DIRECTORYS_LIST_PATH,
+            crate::rest::directory::handler::directorys_handlers::list_directorys_handler,
+        ),
+        (
+            "POST",
+            DIRECTORYS_ACTION_PATH,
+            crate::rest::directory::handler::directorys_handlers::action_directory_handler,
+        ),
+        (
+            "POST",
+            UPLOAD_CHUNK_PATH,
+            crate::rest::directory::handler::directorys_handlers::handle_upload_chunk,
+        ),
+        (
+            "POST",
+            COMPLETE_UPLOAD_PATH,
+            crate::rest::directory::handler::directorys_handlers::handle_complete_upload,
+        ),
+        (
+            "GET",
+            RAW_DOWNLOAD_META_PATH,
+            crate::rest::directory::handler::directorys_handlers::download_file_metadata_handler,
+        ),
+        (
+            "GET",
+            RAW_DOWNLOAD_CHUNK_PATH,
+            crate::rest::directory::handler::directorys_handlers::download_file_chunk_handler,
+        ),
+    ];
+
+    for &(method, path, handler) in routes {
+        debug_log!("Registering {} route: {}", method, path);
+        router::insert_route(method, path, handler);
+    }
+
+}
+
+// src/rest/directorys/handler.rs
+
+
+pub mod directorys_handlers {
+    use crate::{
+        core::{api::{drive::drive::fetch_files_at_folder_path, uuid::generate_unique_id}, state::{directory::{}, drives::state::state::OWNER_ID, raw_storage::{state::{get_file_chunks, store_chunk, store_filename, FILE_META}, types::{ChunkId, FileChunk, CHUNK_SIZE}}}}, debug_log, rest::{auth::{authenticate_request, create_auth_error_response, create_raw_upload_error_response}, directory::types::{CompleteUploadRequest, CompleteUploadResponse, DirectoryActionRequest, DirectoryActionResponse, DirectoryListResponse, ErrorResponse, FileMetadataResponse, ListDirectoryRequest, UploadChunkRequest, UploadChunkResponse}}, 
+        
+    };
+    use ic_http_certification::{HttpRequest, HttpResponse, StatusCode};
+    use matchit::Params;
+    use serde::Deserialize;
+    use urlencoding::decode;
+    #[derive(Deserialize, Default)]
+    struct ListQueryParams {
+        title: Option<String>,
+        completed: Option<bool>,
+    }
+
+    pub fn search_directory_handler(request: &HttpRequest, _params: &Params) -> HttpResponse<'static> {
+        let requester_api_key = match authenticate_request(request) {
+            Some(key) => key,
+            None => return create_auth_error_response(),
+        };
+    
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        if !is_owner {
+            return create_auth_error_response();
+        }
+    
+        let response = DirectoryListResponse {
+            folders: Vec::new(),
+            files: Vec::new(),
+            total_folders: 0,
+            total_files: 0,
+            cursor: None,
+        };
+    
+        create_response(
+            StatusCode::OK,
+            serde_json::to_vec(&response).expect("Failed to serialize response")
+        )
+    }
+
+    pub fn list_directorys_handler(request: &HttpRequest, _params: &Params) -> HttpResponse<'static> {
+        // Authenticate request
+        let requester_api_key = match authenticate_request(request) {
+            Some(key) => key,
+            None => return create_auth_error_response(),
+        };
+    
+        // Only owner can access directories
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        if !is_owner {
+            return create_auth_error_response();
+        }
+    
+        // Parse request body
+        let list_request: ListDirectoryRequest = match serde_json::from_slice(request.body()) {
+            Ok(req) => req,
+            Err(_) => return create_response(
+                StatusCode::BAD_REQUEST,
+                ErrorResponse::err(400, "Invalid request format".to_string()).encode()
+            ),
+        };
+    
+        match fetch_files_at_folder_path(list_request) {
+            Ok(response) => create_response(
+                StatusCode::OK,
+                serde_json::to_vec(&response).expect("Failed to serialize response")
+            ),
+            Err(err) => create_response(
+                StatusCode::NOT_FOUND,
+                ErrorResponse::err(404, format!("Failed to list directory: {:?}", err)).encode()
+            )
+        }
+    }
+
+    pub fn action_directory_handler(request: &HttpRequest, _params: &Params) -> HttpResponse<'static> {
+        let requester_api_key = match authenticate_request(request) {
+            Some(key) => key,
+            None => return create_auth_error_response(),
+        };
+    
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        if !is_owner {
+            return create_auth_error_response();
+        }
+    
+        let action_request: DirectoryActionRequest = match serde_json::from_slice(request.body()) {
+            Ok(req) => req,
+            Err(_) => return create_response(
+                StatusCode::BAD_REQUEST,
+                ErrorResponse::err(400, "Invalid request format".to_string()).encode()
+            ),
+        };
+    
+        // Placeholder that returns empty response for all actions
+        let response = DirectoryActionResponse {
+            data: serde_json::json!({})
+        };
+    
+        create_response(
+            StatusCode::OK,
+            serde_json::to_vec(&response).expect("Failed to serialize response")
+        )
+    }
+
+    pub fn handle_upload_chunk(req: &HttpRequest, _: &Params) -> HttpResponse<'static> {
+        debug_log!("Handling upload chunk request");
+
+        let upload_req: UploadChunkRequest = match serde_json::from_slice(req.body()) {
+            Ok(req) => req,
+            Err(_) => {
+                debug_log!("handle_upload_chunk: Failed to deserialize request");
+                return create_raw_upload_error_response("Invalid request format")
+            }
+        };
+
+        debug_log!("handle_upload_chunk: Handling chunk upload");
+        debug_log!("  file_id      = {}", upload_req.file_id);
+        debug_log!("  chunk_index  = {}", upload_req.chunk_index);
+        debug_log!("  total_chunks = {}", upload_req.total_chunks);
+        debug_log!("  chunk_size   = {}", upload_req.chunk_data.len());
+    
+        if upload_req.chunk_data.len() > CHUNK_SIZE {
+            return create_raw_upload_error_response("Chunk too large");
+        }
+    
+        let chunk_id = ChunkId(format!("{}-{}", upload_req.file_id, upload_req.chunk_index));
+        
+        let chunk = FileChunk {
+            id: chunk_id.clone(),
+            file_id: upload_req.file_id,
+            chunk_index: upload_req.chunk_index,
+            data: upload_req.chunk_data.clone(),
+            size: upload_req.chunk_data.len()
+        };
+        debug_log!("handle_upload_chunk: Storing chunk {:?}", chunk.id);
+    
+        store_chunk(chunk);
+    
+        let response = UploadChunkResponse {
+            chunk_id: chunk_id.0,
+            bytes_received: upload_req.chunk_data.len()
+        };
+    
+        debug_log!("handle_upload_chunk: Successfully stored chunk");
+        create_success_response(&response)
+    }
+    
+    pub fn handle_complete_upload(req: &HttpRequest, _: &Params) -> HttpResponse<'static> {
+        let complete_req: CompleteUploadRequest = match serde_json::from_slice(req.body()) {
+            Ok(req) => req,
+            Err(_) => return create_raw_upload_error_response("Invalid request format")
+        };
+        debug_log!("handle_complete_upload: Completing upload");
+        debug_log!("  file_id = {}", complete_req.file_id);
+
+        store_filename(&complete_req.file_id, &complete_req.filename);
+    
+        let chunks = get_file_chunks(&complete_req.file_id);
+        debug_log!("handle_complete_upload: Found {} chunks", chunks.len());
+
+        let total_size: usize = chunks.iter().map(|c| c.size).sum();
+        debug_log!("handle_complete_upload: Total size = {} bytes", total_size);
+    
+        let response = CompleteUploadResponse {
+            file_id: complete_req.file_id,
+            size: total_size,
+            chunks: chunks.len() as u32,
+            filename: complete_req.filename
+        };
+         debug_log!("handle_complete_upload: Returning final response with size={} chunks={}", response.size, response.chunks);
+    
+        create_success_response(&response)
+    }
+
+    /// Returns the metadata about a file: total size, total chunks, etc.
+    pub fn download_file_metadata_handler(req: &HttpRequest, _: &Params) -> HttpResponse<'static> {
+        debug_log!("download_file_metadata_handler: Handling file metadata request");
+
+        // // 1. Optionally authenticate, if required
+        // let requester_api_key = match authenticate_request(req) {
+        //     Some(key) => key,
+        //     None => return create_auth_error_response(),
+        // };
+
+        // // 2. Check if user is owner, if that's your policy
+        // let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        // if !is_owner {
+        //     return create_auth_error_response();
+        // }
+
+        // 3. Parse query string for file_id
+        let raw_query_string = req.get_query().unwrap_or(Some("".to_string()));
+        let query_string = raw_query_string.as_deref().unwrap_or("");
+        let query_map = crate::rest::helpers::parse_query_string(&query_string);
+
+        let file_id = match query_map.get("file_id") {
+            Some(fid) => fid,
+            None => {
+                return create_response(
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::err(400, "Missing file_id in query".to_string()).encode()
+                );
+            }
+        };
+        let file_id = decode(file_id).unwrap_or_else(|_| file_id.into());
+
+        debug_log!("download_file_metadata_handler: file_id={}", file_id);
+
+        // 4. Collect chunks for this file, if any
+        let mut chunks = get_file_chunks(&file_id);
+        if chunks.is_empty() {
+            return create_response(
+                StatusCode::NOT_FOUND,
+                ErrorResponse::err(404, "File not found".to_string()).encode()
+            );
+        }
+
+        // 5. Sort by chunk index and compute total size
+        chunks.sort_by_key(|c| c.chunk_index);
+        let total_size: usize = chunks.iter().map(|c| c.size).sum();
+        let total_chunks = chunks.len() as u32;
+
+        let filename: String = FILE_META.with(|map| 
+            map.borrow()
+                .get(&file_id.to_string())
+                .cloned()
+        ).unwrap_or_else(|| "unknown.bin".to_string());
+
+        // Create a JSON response with metadata
+        let metadata_response = FileMetadataResponse {
+            file_id: file_id.clone().to_string(),
+            total_size,
+            total_chunks,
+            filename
+        };
+
+        debug_log!(
+            "download_file_metadata_handler: total_size={}, total_chunks={}",
+            total_size,
+            total_chunks
+        );
+
+        create_success_response(&metadata_response)
+    }
+
+    /// Returns the data for a single chunk by index.
+    pub fn download_file_chunk_handler(req: &HttpRequest, _: &Params) -> HttpResponse<'static> {
+        debug_log!("download_file_chunk_handler: Handling file chunk request");
+
+        // // 1. Optionally authenticate
+        // let requester_api_key = match authenticate_request(req) {
+        //     Some(key) => key,
+        //     None => return create_auth_error_response(),
+        // };
+
+        // // 2. Owner check, if you want
+        // let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        // if !is_owner {
+        //     return create_auth_error_response();
+        // }
+
+        // 3. Parse query for file_id & chunk_index
+        let raw_query_string = req.get_query().unwrap_or(Some("".to_string()));
+        let query_string = raw_query_string.as_deref().unwrap_or("");
+        let query_map = crate::rest::helpers::parse_query_string(query_string);
+
+        let file_id = match query_map.get("file_id") {
+            Some(fid) => fid,
+            None => {
+                return create_response(
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::err(400, "Missing file_id".to_string()).encode()
+                );
+            }
+        };
+        let file_id = decode(file_id).unwrap_or_else(|_| file_id.into());
+
+        let chunk_index_str = match query_map.get("chunk_index") {
+            Some(cix) => cix,
+            None => {
+                return create_response(
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::err(400, "Missing chunk_index".to_string()).encode()
+                );
+            }
+        };
+        let chunk_index: u32 = match chunk_index_str.parse() {
+            Ok(num) => num,
+            Err(_) => {
+                return create_response(
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::err(400, "Invalid chunk_index".to_string()).encode()
+                );
+            }
+        };
+
+        debug_log!("download_file_chunk_handler: file_id={}, chunk_index={}", file_id, chunk_index);
+
+        // 4. Retrieve all chunks, or just the one
+        let mut chunks = get_file_chunks(&file_id);
+        chunks.sort_by_key(|c| c.chunk_index);
+
+        // Check if chunk_index is valid
+        if chunk_index as usize >= chunks.len() {
+            return create_response(
+                StatusCode::NOT_FOUND,
+                ErrorResponse::err(404, "Chunk index out of range".to_string()).encode()
+            );
+        }
+
+        let chunk = &chunks[chunk_index as usize];
+        debug_log!("download_file_chunk_handler: Found chunk size={}", chunk.size);
+
+        // 5. Return the chunk data in the HTTP body
+        //    We'll set the content-type to "application/octet-stream".
+        HttpResponse::builder()
+            .with_status_code(StatusCode::OK)
+            .with_headers(vec![
+                ("content-type".to_string(), "application/octet-stream".to_string()),
+                ("cache-control".to_string(), "no-store, max-age=0".to_string()),
+            ])
+            .with_body(chunk.data.clone())
+            .build()
+    }
+
+    fn json_decode<T>(value: &[u8]) -> T
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        serde_json::from_slice(value).expect("Failed to deserialize value")
+    }
+
+    fn create_response(status_code: StatusCode, body: Vec<u8>) -> HttpResponse<'static> {
+        HttpResponse::builder()
+            .with_status_code(status_code)
+            .with_headers(vec![
+                ("content-type".to_string(), "application/json".to_string()),
+                (
+                    "strict-transport-security".to_string(),
+                    "max-age=31536000; includeSubDomains".to_string(),
+                ),
+                ("x-content-type-options".to_string(), "nosniff".to_string()),
+                ("referrer-policy".to_string(), "no-referrer".to_string()),
+                (
+                    "cache-control".to_string(),
+                    "no-store, max-age=0".to_string(),
+                ),
+                ("pragma".to_string(), "no-cache".to_string()),
+            ])
+            .with_body(body)
+            .build()
+    }
+
+    fn create_success_response<T: serde::Serialize>(data: &T) -> HttpResponse<'static> {
+        let body = serde_json::to_vec(data).expect("Failed to serialize response");
+        create_response(StatusCode::OK, body)
+    }
+    
+}
+
+
+
+// src/lib.rs
+use ic_cdk::*;
+use ic_http_certification::{HttpRequest, HttpResponse};
+use core::state::{api_keys::state::state::init_default_admin_apikey, drives::state::state::init_self_drive};
+use std::{cell::RefCell, collections::HashMap};
+
+mod logger;
+mod types;
+mod rest;
+mod core;
+use rest::{router};
+
+#[ic_cdk_macros::init]
+fn init() {
+    debug_log!("Initializing canister...");
+    router::init_routes();
+    init_default_admin_apikey();
+    init_self_drive();  
+}
+
+#[post_upgrade]
+fn post_upgrade() {
+    init();
+}
+
+#[query]
+fn http_request(_req: HttpRequest) -> HttpResponse<'static> {
+    // All requests will be upgraded to update calls
+    HttpResponse::builder()
+        .with_upgrade(true)
+        .build()
+}
+
+#[update]
+fn http_request_update(req: HttpRequest) -> HttpResponse<'static> {
+    router::handle_request(req)
+}

--- a/prompts/refactored-file-upload.prompt.txt
+++ b/prompts/refactored-file-upload.prompt.txt
@@ -1,3 +1,339 @@
+// refactored file upload code
+
+// src/lib.rs
+use ic_cdk::*;
+use ic_http_certification::{HttpRequest, HttpResponse};
+use core::state::{api_keys::state::state::init_default_admin_apikey, drives::state::state::init_self_drive};
+use std::{cell::RefCell, collections::HashMap};
+
+mod logger;
+mod types;
+mod rest;
+mod core;
+use rest::{router};
+
+#[ic_cdk_macros::init]
+fn init() {
+    debug_log!("Initializing canister...");
+    router::init_routes();
+    init_default_admin_apikey();
+    init_self_drive();  
+}
+
+#[post_upgrade]
+fn post_upgrade() {
+    init();
+}
+
+#[query]
+fn http_request(_req: HttpRequest) -> HttpResponse<'static> {
+    // All requests will be upgraded to update calls
+    HttpResponse::builder()
+        .with_upgrade(true)
+        .build()
+}
+
+#[update]
+fn http_request_update(req: HttpRequest) -> HttpResponse<'static> {
+    router::handle_request(req)
+}
+
+// src/core/state/raw_storage/state.rs
+use ic_stable_structures::{
+    memory_manager::{MemoryId, MemoryManager},
+    DefaultMemoryImpl, 
+    StableBTreeMap,
+    Memory
+};
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use crate::core::state::raw_storage::types::{ChunkId, FileChunk};
+
+const CHUNKS_MEM_ID: MemoryId = MemoryId::new(1);
+const FILE_CHUNKS_MEM_ID: MemoryId = MemoryId::new(2);
+const FILE_META_MEM_ID: MemoryId = MemoryId::new(3);
+
+thread_local! {
+    // Initialize the memory manager
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = RefCell::new(
+        MemoryManager::init(DefaultMemoryImpl::default())
+    );
+
+    // Store chunks in stable memory using a different initialization approach
+    static STABLE_CHUNKS: RefCell<StableBTreeMap<ChunkId, Vec<u8>, DefaultMemoryImpl>> = RefCell::new(
+        StableBTreeMap::new(DefaultMemoryImpl::default())
+    );
+
+    // Store chunk metadata in heap memory
+    static CHUNKS: RefCell<BTreeMap<ChunkId, FileChunk>> = RefCell::new(BTreeMap::new());
+    static FILE_CHUNKS: RefCell<BTreeMap<String, Vec<ChunkId>>> = RefCell::new(BTreeMap::new());
+    pub(crate) static FILE_META: RefCell<BTreeMap<String, String>> = RefCell::new(BTreeMap::new());
+}
+
+pub fn store_chunk(chunk: FileChunk) {
+    STABLE_CHUNKS.with(|chunks| {
+        chunks.borrow_mut().insert(chunk.id.clone(), chunk.data.clone());
+    });
+
+    CHUNKS.with(|chunks| {
+        chunks.borrow_mut().insert(chunk.id.clone(), chunk.clone());
+    });
+
+    FILE_CHUNKS.with(|file_chunks| {
+        let mut map = file_chunks.borrow_mut();
+        map.entry(chunk.file_id.clone())
+           .or_insert_with(Vec::new)
+           .push(chunk.id);
+    });
+}
+
+pub fn get_chunk(chunk_id: &ChunkId) -> Option<FileChunk> {
+    CHUNKS.with(|chunks| chunks.borrow().get(chunk_id).cloned())
+}
+
+pub fn get_file_chunks(file_id: &str) -> Vec<FileChunk> {
+    FILE_CHUNKS.with(|file_chunks| {
+        if let Some(chunk_ids) = file_chunks.borrow().get(file_id) {
+            chunk_ids.iter()
+                    .filter_map(|id| get_chunk(id))
+                    .collect()
+        } else {
+            Vec::new()
+        }
+    })
+}
+
+pub fn store_filename(file_id: &str, filename: &str) {
+    FILE_META.with(|fmeta| {
+        fmeta.borrow_mut().insert(file_id.to_string(), filename.to_string());
+    });
+}
+
+pub fn get_filename(file_id: &str) -> Option<String> {
+    FILE_META.with(|fmeta| {
+        fmeta.borrow().get(file_id).cloned()
+    })
+}
+
+// src/core/state/raw_storage/types.rs
+use candid::{CandidType, Decode, Encode}; 
+use ic_stable_structures::{Storable, storable::Bound};
+use serde::{Deserialize, Serialize};
+use std::{borrow::Cow, fmt};
+
+pub const CHUNK_SIZE: usize = 2 * 1024 * 1024; // 2MB chunks
+
+#[derive(Debug, Clone, CandidType, Serialize, Deserialize, Ord, PartialOrd, Eq, PartialEq)]
+pub struct ChunkId(pub String);
+
+impl fmt::Display for ChunkId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Storable for ChunkId {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(Encode!(self).unwrap()) 
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(bytes.as_ref(), Self).unwrap()
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+#[derive(Debug, Clone, CandidType, Serialize, Deserialize)]
+pub struct FileChunk {
+    pub id: ChunkId,
+    pub file_id: String,
+    pub chunk_index: u32,
+    pub data: Vec<u8>,
+    pub size: usize
+}
+
+impl Storable for FileChunk {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(Encode!(self).unwrap())
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(bytes.as_ref(), Self).unwrap()
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+// src/rest/directorys/types.rs
+
+use serde::{Deserialize, Serialize};
+use crate::{core::state::directory::types::{FileMetadata, FolderMetadata}, rest::webhooks::types::SortDirection};
+
+#[derive(Debug, Clone, Deserialize)]
+pub enum DirectoryAction {
+    #[serde(rename = "get")]
+    Get,
+    #[serde(rename = "create")]
+    Create,
+    #[serde(rename = "update")]
+    Update,
+    #[serde(rename = "delete")]
+    Delete,
+    #[serde(rename = "copy")]
+    Copy,
+    #[serde(rename = "move")]
+    Move,
+    #[serde(rename = "sync")]
+    Sync,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DirectoryActionRequest {
+    pub action: DirectoryAction,
+    #[serde(flatten)]
+    pub params: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DirectoryActionResponse {
+    #[serde(flatten)]
+    pub data: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SearchDirectoryRequest {
+    pub query_string: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListDirectoryRequest {
+    pub folder_id: Option<String>,
+    pub path: Option<String>,
+    #[serde(default)]
+    pub filters: String,
+    #[serde(default = "default_page_size")]
+    pub page_size: usize,
+    #[serde(default)]
+    pub direction: SortDirection,
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DirectoryListResponse {
+    pub folders: Vec<FolderMetadata>,
+    pub files: Vec<FileMetadata>,
+    pub total_files: usize,
+    pub total_folders: usize,
+    pub cursor: Option<String>,
+}
+
+fn default_page_size() -> usize {
+    50
+}
+
+
+
+pub type SearchDirectoryResponse = DirectoryListResponse;
+
+pub type DirectoryResponse<'a, T> = crate::rest::drives::types::DriveResponse<'a, T>;
+pub type ErrorResponse<'a> = DirectoryResponse<'a, ()>;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UploadChunkRequest {
+    pub file_id: String,
+    pub chunk_index: u32,
+    pub chunk_data: Vec<u8>,
+    pub total_chunks: u32
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UploadChunkResponse {
+    pub chunk_id: String,
+    pub bytes_received: usize
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CompleteUploadRequest {
+    pub file_id: String,
+    pub filename: String
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CompleteUploadResponse {
+    pub file_id: String,
+    pub size: usize,
+    pub chunks: u32,
+    pub filename: String
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FileMetadataResponse {
+    pub file_id: String,
+    pub total_size: usize,
+    pub total_chunks: u32,
+    pub filename: String
+}
+
+
+
+// src/rest/directorys/route.rs
+use crate::debug_log;
+use crate::rest::router;
+use crate::types::RouteHandler;
+
+pub const DIRECTORYS_SEARCH_PATH: &str = "/directory/search";
+pub const DIRECTORYS_LIST_PATH: &str = "/directory/list";
+pub const DIRECTORYS_ACTION_PATH: &str = "/directory/action";
+
+pub const UPLOAD_CHUNK_PATH: &str = "/directory/raw_upload/chunk";
+pub const COMPLETE_UPLOAD_PATH: &str = "/directory/raw_upload/complete";
+pub const ASSET_PATH: &str = "/asset/{file_id}";
+
+type HandlerEntry = (&'static str, &'static str, RouteHandler);
+
+pub fn init_routes() {
+    let routes: &[HandlerEntry] = &[
+        (
+            "POST",
+            DIRECTORYS_SEARCH_PATH,
+            crate::rest::directory::handler::directorys_handlers::search_directory_handler,
+        ),
+        (
+            "POST",
+            DIRECTORYS_LIST_PATH,
+            crate::rest::directory::handler::directorys_handlers::list_directorys_handler,
+        ),
+        (
+            "POST",
+            DIRECTORYS_ACTION_PATH,
+            crate::rest::directory::handler::directorys_handlers::action_directory_handler,
+        ),
+        (
+            "POST",
+            UPLOAD_CHUNK_PATH,
+            crate::rest::directory::handler::directorys_handlers::handle_upload_chunk,
+        ),
+        (
+            "POST", 
+            COMPLETE_UPLOAD_PATH,
+            crate::rest::directory::handler::directorys_handlers::handle_complete_upload,
+        ),
+        (
+            "GET",
+            ASSET_PATH,
+            crate::rest::directory::handler::directorys_handlers::serve_asset,
+        ),
+    ];
+
+    for &(method, path, handler) in routes {
+        debug_log!("Registering {} route: {}", method, path);
+        router::insert_route(method, path, handler);
+    }
+
+}
+
 // src/rest/directorys/handler.rs
 
 

--- a/src/canisters-official-backend/Cargo.toml
+++ b/src/canisters-official-backend/Cargo.toml
@@ -29,3 +29,4 @@ ic-stable-structures = "0.6.7"
 ciborium = "0.2.2"
 urlencoding = "2.1.3"
 url = "2.5.4"
+hyperx = { git = "https://github.com/ldclabs/hyperx", rev = "4b9bd373b8c4d29a32e59912bf598ba69273c032" }

--- a/src/canisters-official-backend/src/core/state/raw_storage/state.rs
+++ b/src/canisters-official-backend/src/core/state/raw_storage/state.rs
@@ -1,15 +1,41 @@
 // src/core/state/raw_storage/state.rs
+use ic_stable_structures::{
+    memory_manager::{MemoryId, MemoryManager},
+    DefaultMemoryImpl, 
+    StableBTreeMap,
+    Memory
+};
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
+use std::rc::Rc;
 use crate::core::state::raw_storage::types::{ChunkId, FileChunk};
 
+const CHUNKS_MEM_ID: MemoryId = MemoryId::new(1);
+const FILE_CHUNKS_MEM_ID: MemoryId = MemoryId::new(2);
+const FILE_META_MEM_ID: MemoryId = MemoryId::new(3);
+
 thread_local! {
-    pub static CHUNKS: RefCell<HashMap<ChunkId, FileChunk>> = RefCell::new(HashMap::new());
-    pub static FILE_CHUNKS: RefCell<HashMap<String, Vec<ChunkId>>> = RefCell::new(HashMap::new());
-    pub static FILE_META: RefCell<HashMap<String, String>> = RefCell::new(HashMap::new());
+    // Initialize the memory manager
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = RefCell::new(
+        MemoryManager::init(DefaultMemoryImpl::default())
+    );
+
+    // Store chunks in stable memory using a different initialization approach
+    static STABLE_CHUNKS: RefCell<StableBTreeMap<ChunkId, Vec<u8>, DefaultMemoryImpl>> = RefCell::new(
+        StableBTreeMap::new(DefaultMemoryImpl::default())
+    );
+
+    // Store chunk metadata in heap memory
+    static CHUNKS: RefCell<BTreeMap<ChunkId, FileChunk>> = RefCell::new(BTreeMap::new());
+    pub(crate) static FILE_CHUNKS: RefCell<BTreeMap<String, Vec<ChunkId>>> = RefCell::new(BTreeMap::new());
+    pub(crate) static FILE_META: RefCell<BTreeMap<String, String>> = RefCell::new(BTreeMap::new());
 }
 
 pub fn store_chunk(chunk: FileChunk) {
+    STABLE_CHUNKS.with(|chunks| {
+        chunks.borrow_mut().insert(chunk.id.clone(), chunk.data.clone());
+    });
+
     CHUNKS.with(|chunks| {
         chunks.borrow_mut().insert(chunk.id.clone(), chunk.clone());
     });
@@ -29,8 +55,13 @@ pub fn get_chunk(chunk_id: &ChunkId) -> Option<FileChunk> {
 pub fn get_file_chunks(file_id: &str) -> Vec<FileChunk> {
     FILE_CHUNKS.with(|file_chunks| {
         if let Some(chunk_ids) = file_chunks.borrow().get(file_id) {
+            // Get chunks using the stored chunk IDs
             chunk_ids.iter()
-                    .filter_map(|id| get_chunk(id))
+                    .filter_map(|chunk_id| {
+                        CHUNKS.with(|chunks| {
+                            chunks.borrow().get(chunk_id).cloned()
+                        })
+                    })
                     .collect()
         } else {
             Vec::new()
@@ -38,9 +69,14 @@ pub fn get_file_chunks(file_id: &str) -> Vec<FileChunk> {
     })
 }
 
-
 pub fn store_filename(file_id: &str, filename: &str) {
     FILE_META.with(|fmeta| {
         fmeta.borrow_mut().insert(file_id.to_string(), filename.to_string());
     });
+}
+
+pub fn get_filename(file_id: &str) -> Option<String> {
+    FILE_META.with(|fmeta| {
+        fmeta.borrow().get(file_id).cloned()
+    })
 }

--- a/src/canisters-official-backend/src/core/state/raw_storage/types.rs
+++ b/src/canisters-official-backend/src/core/state/raw_storage/types.rs
@@ -1,8 +1,12 @@
 // src/core/state/raw_storage/types.rs
+use candid::{CandidType, Decode, Encode}; 
+use ic_stable_structures::{Storable, storable::Bound};
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub const CHUNK_SIZE: usize = 2 * 1024 * 1024; // 2MB chunks
+
+#[derive(Debug, Clone, CandidType, Serialize, Deserialize, Ord, PartialOrd, Eq, PartialEq)]
 pub struct ChunkId(pub String);
 
 impl fmt::Display for ChunkId {
@@ -11,7 +15,19 @@ impl fmt::Display for ChunkId {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+impl Storable for ChunkId {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(Encode!(self).unwrap()) 
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(bytes.as_ref(), Self).unwrap()
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+#[derive(Debug, Clone, CandidType, Serialize, Deserialize)]
 pub struct FileChunk {
     pub id: ChunkId,
     pub file_id: String,
@@ -20,4 +36,14 @@ pub struct FileChunk {
     pub size: usize
 }
 
-pub const CHUNK_SIZE: usize = 3 * 1024 * (1024 / 2); // 1.5MB chunks
+impl Storable for FileChunk {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(Encode!(self).unwrap())
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(bytes.as_ref(), Self).unwrap()
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}

--- a/src/canisters-official-backend/src/rest/directory/route.rs
+++ b/src/canisters-official-backend/src/rest/directory/route.rs
@@ -6,10 +6,10 @@ use crate::types::RouteHandler;
 pub const DIRECTORYS_SEARCH_PATH: &str = "/directory/search";
 pub const DIRECTORYS_LIST_PATH: &str = "/directory/list";
 pub const DIRECTORYS_ACTION_PATH: &str = "/directory/action";
+
 pub const UPLOAD_CHUNK_PATH: &str = "/directory/raw_upload/chunk";
 pub const COMPLETE_UPLOAD_PATH: &str = "/directory/raw_upload/complete";
-pub const RAW_DOWNLOAD_META_PATH: &str = "/directory/raw_download/meta";
-pub const RAW_DOWNLOAD_CHUNK_PATH: &str = "/directory/raw_download/chunk";
+pub const ASSET_PATH: &str = "/asset/{file_id}";
 
 type HandlerEntry = (&'static str, &'static str, RouteHandler);
 
@@ -36,19 +36,14 @@ pub fn init_routes() {
             crate::rest::directory::handler::directorys_handlers::handle_upload_chunk,
         ),
         (
-            "POST",
+            "POST", 
             COMPLETE_UPLOAD_PATH,
             crate::rest::directory::handler::directorys_handlers::handle_complete_upload,
         ),
         (
             "GET",
-            RAW_DOWNLOAD_META_PATH,
-            crate::rest::directory::handler::directorys_handlers::download_file_metadata_handler,
-        ),
-        (
-            "GET",
-            RAW_DOWNLOAD_CHUNK_PATH,
-            crate::rest::directory::handler::directorys_handlers::download_file_chunk_handler,
+            ASSET_PATH,
+            crate::rest::directory::handler::directorys_handlers::serve_asset,
         ),
     ];
 

--- a/src/canisters-official-backend/src/rest/directory/types.rs
+++ b/src/canisters-official-backend/src/rest/directory/types.rs
@@ -1,4 +1,5 @@
 // src/rest/directorys/types.rs
+
 use serde::{Deserialize, Serialize};
 use crate::{core::state::directory::types::{FileMetadata, FolderMetadata}, rest::webhooks::types::SortDirection};
 
@@ -65,6 +66,12 @@ fn default_page_size() -> usize {
 }
 
 
+
+pub type SearchDirectoryResponse = DirectoryListResponse;
+
+pub type DirectoryResponse<'a, T> = crate::rest::drives::types::DriveResponse<'a, T>;
+pub type ErrorResponse<'a> = DirectoryResponse<'a, ()>;
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct UploadChunkRequest {
     pub file_id: String,
@@ -79,7 +86,7 @@ pub struct UploadChunkResponse {
     pub bytes_received: usize
 }
 
-#[derive(Debug, Clone, Deserialize)] 
+#[derive(Debug, Clone, Deserialize)]
 pub struct CompleteUploadRequest {
     pub file_id: String,
     pub filename: String
@@ -93,8 +100,7 @@ pub struct CompleteUploadResponse {
     pub filename: String
 }
 
-
-#[derive(serde::Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct FileMetadataResponse {
     pub file_id: String,
     pub total_size: usize,
@@ -102,7 +108,3 @@ pub struct FileMetadataResponse {
     pub filename: String
 }
 
-pub type SearchDirectoryResponse = DirectoryListResponse;
-
-pub type DirectoryResponse<'a, T> = crate::rest::drives::types::DriveResponse<'a, T>;
-pub type ErrorResponse<'a> = DirectoryResponse<'a, ()>;


### PR DESCRIPTION
- working simple implementation of icp http canisters for storage
- should move chunks into long term storage not ephemeral