### PR TITLE
Canister filestorage simple

### DIFF
--- a/CONTEXT.txt
+++ b/CONTEXT.txt
@@ -1,0 +1,644 @@
+// src/core/state/raw_storage/state.rs
+use std::cell::RefCell;
+use std::collections::HashMap;
+use crate::core::state::raw_storage::types::{ChunkId, FileChunk};
+
+thread_local! {
+    pub static CHUNKS: RefCell<HashMap<ChunkId, FileChunk>> = RefCell::new(HashMap::new());
+    pub static FILE_CHUNKS: RefCell<HashMap<String, Vec<ChunkId>>> = RefCell::new(HashMap::new());
+    pub static FILE_META: RefCell<HashMap<String, String>> = RefCell::new(HashMap::new());
+}
+
+pub fn store_chunk(chunk: FileChunk) {
+    CHUNKS.with(|chunks| {
+        chunks.borrow_mut().insert(chunk.id.clone(), chunk.clone());
+    });
+
+    FILE_CHUNKS.with(|file_chunks| {
+        let mut map = file_chunks.borrow_mut();
+        map.entry(chunk.file_id.clone())
+           .or_insert_with(Vec::new)
+           .push(chunk.id);
+    });
+}
+
+pub fn get_chunk(chunk_id: &ChunkId) -> Option<FileChunk> {
+    CHUNKS.with(|chunks| chunks.borrow().get(chunk_id).cloned())
+}
+
+pub fn get_file_chunks(file_id: &str) -> Vec<FileChunk> {
+    FILE_CHUNKS.with(|file_chunks| {
+        if let Some(chunk_ids) = file_chunks.borrow().get(file_id) {
+            chunk_ids.iter()
+                    .filter_map(|id| get_chunk(id))
+                    .collect()
+        } else {
+            Vec::new()
+        }
+    })
+}
+
+
+pub fn store_filename(file_id: &str, filename: &str) {
+    FILE_META.with(|fmeta| {
+        fmeta.borrow_mut().insert(file_id.to_string(), filename.to_string());
+    });
+}
+
+// src/core/state/raw_storage/types.rs
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ChunkId(pub String);
+
+impl fmt::Display for ChunkId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileChunk {
+    pub id: ChunkId,
+    pub file_id: String,
+    pub chunk_index: u32,
+    pub data: Vec<u8>,
+    pub size: usize
+}
+
+pub const CHUNK_SIZE: usize = 3 * 1024 * (1024 / 2); // 1.5MB chunks
+
+// src/rest/directorys/types.rs
+use serde::{Deserialize, Serialize};
+use crate::{core::state::directory::types::{FileMetadata, FolderMetadata}, rest::webhooks::types::SortDirection};
+
+#[derive(Debug, Clone, Deserialize)]
+pub enum DirectoryAction {
+    #[serde(rename = "get")]
+    Get,
+    #[serde(rename = "create")]
+    Create,
+    #[serde(rename = "update")]
+    Update,
+    #[serde(rename = "delete")]
+    Delete,
+    #[serde(rename = "copy")]
+    Copy,
+    #[serde(rename = "move")]
+    Move,
+    #[serde(rename = "sync")]
+    Sync,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DirectoryActionRequest {
+    pub action: DirectoryAction,
+    #[serde(flatten)]
+    pub params: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DirectoryActionResponse {
+    #[serde(flatten)]
+    pub data: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SearchDirectoryRequest {
+    pub query_string: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListDirectoryRequest {
+    pub folder_id: Option<String>,
+    pub path: Option<String>,
+    #[serde(default)]
+    pub filters: String,
+    #[serde(default = "default_page_size")]
+    pub page_size: usize,
+    #[serde(default)]
+    pub direction: SortDirection,
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DirectoryListResponse {
+    pub folders: Vec<FolderMetadata>,
+    pub files: Vec<FileMetadata>,
+    pub total_files: usize,
+    pub total_folders: usize,
+    pub cursor: Option<String>,
+}
+
+fn default_page_size() -> usize {
+    50
+}
+
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UploadChunkRequest {
+    pub file_id: String,
+    pub chunk_index: u32,
+    pub chunk_data: Vec<u8>,
+    pub total_chunks: u32
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UploadChunkResponse {
+    pub chunk_id: String,
+    pub bytes_received: usize
+}
+
+#[derive(Debug, Clone, Deserialize)] 
+pub struct CompleteUploadRequest {
+    pub file_id: String,
+    pub filename: String
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CompleteUploadResponse {
+    pub file_id: String,
+    pub size: usize,
+    pub chunks: u32,
+    pub filename: String
+}
+
+
+#[derive(serde::Serialize)]
+pub struct FileMetadataResponse {
+    pub file_id: String,
+    pub total_size: usize,
+    pub total_chunks: u32,
+    pub filename: String
+}
+
+pub type SearchDirectoryResponse = DirectoryListResponse;
+
+pub type DirectoryResponse<'a, T> = crate::rest::drives::types::DriveResponse<'a, T>;
+pub type ErrorResponse<'a> = DirectoryResponse<'a, ()>;
+
+
+// src/rest/directorys/route.rs
+use crate::debug_log;
+use crate::rest::router;
+use crate::types::RouteHandler;
+
+pub const DIRECTORYS_SEARCH_PATH: &str = "/directory/search";
+pub const DIRECTORYS_LIST_PATH: &str = "/directory/list";
+pub const DIRECTORYS_ACTION_PATH: &str = "/directory/action";
+pub const UPLOAD_CHUNK_PATH: &str = "/directory/raw_upload/chunk";
+pub const COMPLETE_UPLOAD_PATH: &str = "/directory/raw_upload/complete";
+pub const RAW_DOWNLOAD_META_PATH: &str = "/directory/raw_download/meta";
+pub const RAW_DOWNLOAD_CHUNK_PATH: &str = "/directory/raw_download/chunk";
+
+type HandlerEntry = (&'static str, &'static str, RouteHandler);
+
+pub fn init_routes() {
+    let routes: &[HandlerEntry] = &[
+        (
+            "POST",
+            DIRECTORYS_SEARCH_PATH,
+            crate::rest::directory::handler::directorys_handlers::search_directory_handler,
+        ),
+        (
+            "POST",
+            DIRECTORYS_LIST_PATH,
+            crate::rest::directory::handler::directorys_handlers::list_directorys_handler,
+        ),
+        (
+            "POST",
+            DIRECTORYS_ACTION_PATH,
+            crate::rest::directory::handler::directorys_handlers::action_directory_handler,
+        ),
+        (
+            "POST",
+            UPLOAD_CHUNK_PATH,
+            crate::rest::directory::handler::directorys_handlers::handle_upload_chunk,
+        ),
+        (
+            "POST",
+            COMPLETE_UPLOAD_PATH,
+            crate::rest::directory::handler::directorys_handlers::handle_complete_upload,
+        ),
+        (
+            "GET",
+            RAW_DOWNLOAD_META_PATH,
+            crate::rest::directory::handler::directorys_handlers::download_file_metadata_handler,
+        ),
+        (
+            "GET",
+            RAW_DOWNLOAD_CHUNK_PATH,
+            crate::rest::directory::handler::directorys_handlers::download_file_chunk_handler,
+        ),
+    ];
+
+    for &(method, path, handler) in routes {
+        debug_log!("Registering {} route: {}", method, path);
+        router::insert_route(method, path, handler);
+    }
+
+}
+
+// src/rest/directorys/handler.rs
+
+
+pub mod directorys_handlers {
+    use crate::{
+        core::{api::{drive::drive::fetch_files_at_folder_path, uuid::generate_unique_id}, state::{directory::{}, drives::state::state::OWNER_ID, raw_storage::{state::{get_file_chunks, store_chunk, store_filename, FILE_META}, types::{ChunkId, FileChunk, CHUNK_SIZE}}}}, debug_log, rest::{auth::{authenticate_request, create_auth_error_response, create_raw_upload_error_response}, directory::types::{CompleteUploadRequest, CompleteUploadResponse, DirectoryActionRequest, DirectoryActionResponse, DirectoryListResponse, ErrorResponse, FileMetadataResponse, ListDirectoryRequest, UploadChunkRequest, UploadChunkResponse}}, 
+        
+    };
+    use ic_http_certification::{HttpRequest, HttpResponse, StatusCode};
+    use matchit::Params;
+    use serde::Deserialize;
+    use urlencoding::decode;
+    #[derive(Deserialize, Default)]
+    struct ListQueryParams {
+        title: Option<String>,
+        completed: Option<bool>,
+    }
+
+    pub fn search_directory_handler(request: &HttpRequest, _params: &Params) -> HttpResponse<'static> {
+        let requester_api_key = match authenticate_request(request) {
+            Some(key) => key,
+            None => return create_auth_error_response(),
+        };
+    
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        if !is_owner {
+            return create_auth_error_response();
+        }
+    
+        let response = DirectoryListResponse {
+            folders: Vec::new(),
+            files: Vec::new(),
+            total_folders: 0,
+            total_files: 0,
+            cursor: None,
+        };
+    
+        create_response(
+            StatusCode::OK,
+            serde_json::to_vec(&response).expect("Failed to serialize response")
+        )
+    }
+
+    pub fn list_directorys_handler(request: &HttpRequest, _params: &Params) -> HttpResponse<'static> {
+        // Authenticate request
+        let requester_api_key = match authenticate_request(request) {
+            Some(key) => key,
+            None => return create_auth_error_response(),
+        };
+    
+        // Only owner can access directories
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        if !is_owner {
+            return create_auth_error_response();
+        }
+    
+        // Parse request body
+        let list_request: ListDirectoryRequest = match serde_json::from_slice(request.body()) {
+            Ok(req) => req,
+            Err(_) => return create_response(
+                StatusCode::BAD_REQUEST,
+                ErrorResponse::err(400, "Invalid request format".to_string()).encode()
+            ),
+        };
+    
+        match fetch_files_at_folder_path(list_request) {
+            Ok(response) => create_response(
+                StatusCode::OK,
+                serde_json::to_vec(&response).expect("Failed to serialize response")
+            ),
+            Err(err) => create_response(
+                StatusCode::NOT_FOUND,
+                ErrorResponse::err(404, format!("Failed to list directory: {:?}", err)).encode()
+            )
+        }
+    }
+
+    pub fn action_directory_handler(request: &HttpRequest, _params: &Params) -> HttpResponse<'static> {
+        let requester_api_key = match authenticate_request(request) {
+            Some(key) => key,
+            None => return create_auth_error_response(),
+        };
+    
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        if !is_owner {
+            return create_auth_error_response();
+        }
+    
+        let action_request: DirectoryActionRequest = match serde_json::from_slice(request.body()) {
+            Ok(req) => req,
+            Err(_) => return create_response(
+                StatusCode::BAD_REQUEST,
+                ErrorResponse::err(400, "Invalid request format".to_string()).encode()
+            ),
+        };
+    
+        // Placeholder that returns empty response for all actions
+        let response = DirectoryActionResponse {
+            data: serde_json::json!({})
+        };
+    
+        create_response(
+            StatusCode::OK,
+            serde_json::to_vec(&response).expect("Failed to serialize response")
+        )
+    }
+
+    pub fn handle_upload_chunk(req: &HttpRequest, _: &Params) -> HttpResponse<'static> {
+        debug_log!("Handling upload chunk request");
+
+        let upload_req: UploadChunkRequest = match serde_json::from_slice(req.body()) {
+            Ok(req) => req,
+            Err(_) => {
+                debug_log!("handle_upload_chunk: Failed to deserialize request");
+                return create_raw_upload_error_response("Invalid request format")
+            }
+        };
+
+        debug_log!("handle_upload_chunk: Handling chunk upload");
+        debug_log!("  file_id      = {}", upload_req.file_id);
+        debug_log!("  chunk_index  = {}", upload_req.chunk_index);
+        debug_log!("  total_chunks = {}", upload_req.total_chunks);
+        debug_log!("  chunk_size   = {}", upload_req.chunk_data.len());
+    
+        if upload_req.chunk_data.len() > CHUNK_SIZE {
+            return create_raw_upload_error_response("Chunk too large");
+        }
+    
+        let chunk_id = ChunkId(format!("{}-{}", upload_req.file_id, upload_req.chunk_index));
+        
+        let chunk = FileChunk {
+            id: chunk_id.clone(),
+            file_id: upload_req.file_id,
+            chunk_index: upload_req.chunk_index,
+            data: upload_req.chunk_data.clone(),
+            size: upload_req.chunk_data.len()
+        };
+        debug_log!("handle_upload_chunk: Storing chunk {:?}", chunk.id);
+    
+        store_chunk(chunk);
+    
+        let response = UploadChunkResponse {
+            chunk_id: chunk_id.0,
+            bytes_received: upload_req.chunk_data.len()
+        };
+    
+        debug_log!("handle_upload_chunk: Successfully stored chunk");
+        create_success_response(&response)
+    }
+    
+    pub fn handle_complete_upload(req: &HttpRequest, _: &Params) -> HttpResponse<'static> {
+        let complete_req: CompleteUploadRequest = match serde_json::from_slice(req.body()) {
+            Ok(req) => req,
+            Err(_) => return create_raw_upload_error_response("Invalid request format")
+        };
+        debug_log!("handle_complete_upload: Completing upload");
+        debug_log!("  file_id = {}", complete_req.file_id);
+
+        store_filename(&complete_req.file_id, &complete_req.filename);
+    
+        let chunks = get_file_chunks(&complete_req.file_id);
+        debug_log!("handle_complete_upload: Found {} chunks", chunks.len());
+
+        let total_size: usize = chunks.iter().map(|c| c.size).sum();
+        debug_log!("handle_complete_upload: Total size = {} bytes", total_size);
+    
+        let response = CompleteUploadResponse {
+            file_id: complete_req.file_id,
+            size: total_size,
+            chunks: chunks.len() as u32,
+            filename: complete_req.filename
+        };
+         debug_log!("handle_complete_upload: Returning final response with size={} chunks={}", response.size, response.chunks);
+    
+        create_success_response(&response)
+    }
+
+    /// Returns the metadata about a file: total size, total chunks, etc.
+    pub fn download_file_metadata_handler(req: &HttpRequest, _: &Params) -> HttpResponse<'static> {
+        debug_log!("download_file_metadata_handler: Handling file metadata request");
+
+        // // 1. Optionally authenticate, if required
+        // let requester_api_key = match authenticate_request(req) {
+        //     Some(key) => key,
+        //     None => return create_auth_error_response(),
+        // };
+
+        // // 2. Check if user is owner, if that's your policy
+        // let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        // if !is_owner {
+        //     return create_auth_error_response();
+        // }
+
+        // 3. Parse query string for file_id
+        let raw_query_string = req.get_query().unwrap_or(Some("".to_string()));
+        let query_string = raw_query_string.as_deref().unwrap_or("");
+        let query_map = crate::rest::helpers::parse_query_string(&query_string);
+
+        let file_id = match query_map.get("file_id") {
+            Some(fid) => fid,
+            None => {
+                return create_response(
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::err(400, "Missing file_id in query".to_string()).encode()
+                );
+            }
+        };
+        let file_id = decode(file_id).unwrap_or_else(|_| file_id.into());
+
+        debug_log!("download_file_metadata_handler: file_id={}", file_id);
+
+        // 4. Collect chunks for this file, if any
+        let mut chunks = get_file_chunks(&file_id);
+        if chunks.is_empty() {
+            return create_response(
+                StatusCode::NOT_FOUND,
+                ErrorResponse::err(404, "File not found".to_string()).encode()
+            );
+        }
+
+        // 5. Sort by chunk index and compute total size
+        chunks.sort_by_key(|c| c.chunk_index);
+        let total_size: usize = chunks.iter().map(|c| c.size).sum();
+        let total_chunks = chunks.len() as u32;
+
+        let filename: String = FILE_META.with(|map| 
+            map.borrow()
+                .get(&file_id.to_string())
+                .cloned()
+        ).unwrap_or_else(|| "unknown.bin".to_string());
+
+        // Create a JSON response with metadata
+        let metadata_response = FileMetadataResponse {
+            file_id: file_id.clone().to_string(),
+            total_size,
+            total_chunks,
+            filename
+        };
+
+        debug_log!(
+            "download_file_metadata_handler: total_size={}, total_chunks={}",
+            total_size,
+            total_chunks
+        );
+
+        create_success_response(&metadata_response)
+    }
+
+    /// Returns the data for a single chunk by index.
+    pub fn download_file_chunk_handler(req: &HttpRequest, _: &Params) -> HttpResponse<'static> {
+        debug_log!("download_file_chunk_handler: Handling file chunk request");
+
+        // // 1. Optionally authenticate
+        // let requester_api_key = match authenticate_request(req) {
+        //     Some(key) => key,
+        //     None => return create_auth_error_response(),
+        // };
+
+        // // 2. Owner check, if you want
+        // let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id);
+        // if !is_owner {
+        //     return create_auth_error_response();
+        // }
+
+        // 3. Parse query for file_id & chunk_index
+        let raw_query_string = req.get_query().unwrap_or(Some("".to_string()));
+        let query_string = raw_query_string.as_deref().unwrap_or("");
+        let query_map = crate::rest::helpers::parse_query_string(query_string);
+
+        let file_id = match query_map.get("file_id") {
+            Some(fid) => fid,
+            None => {
+                return create_response(
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::err(400, "Missing file_id".to_string()).encode()
+                );
+            }
+        };
+        let file_id = decode(file_id).unwrap_or_else(|_| file_id.into());
+
+        let chunk_index_str = match query_map.get("chunk_index") {
+            Some(cix) => cix,
+            None => {
+                return create_response(
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::err(400, "Missing chunk_index".to_string()).encode()
+                );
+            }
+        };
+        let chunk_index: u32 = match chunk_index_str.parse() {
+            Ok(num) => num,
+            Err(_) => {
+                return create_response(
+                    StatusCode::BAD_REQUEST,
+                    ErrorResponse::err(400, "Invalid chunk_index".to_string()).encode()
+                );
+            }
+        };
+
+        debug_log!("download_file_chunk_handler: file_id={}, chunk_index={}", file_id, chunk_index);
+
+        // 4. Retrieve all chunks, or just the one
+        let mut chunks = get_file_chunks(&file_id);
+        chunks.sort_by_key(|c| c.chunk_index);
+
+        // Check if chunk_index is valid
+        if chunk_index as usize >= chunks.len() {
+            return create_response(
+                StatusCode::NOT_FOUND,
+                ErrorResponse::err(404, "Chunk index out of range".to_string()).encode()
+            );
+        }
+
+        let chunk = &chunks[chunk_index as usize];
+        debug_log!("download_file_chunk_handler: Found chunk size={}", chunk.size);
+
+        // 5. Return the chunk data in the HTTP body
+        //    We'll set the content-type to "application/octet-stream".
+        HttpResponse::builder()
+            .with_status_code(StatusCode::OK)
+            .with_headers(vec![
+                ("content-type".to_string(), "application/octet-stream".to_string()),
+                ("cache-control".to_string(), "no-store, max-age=0".to_string()),
+            ])
+            .with_body(chunk.data.clone())
+            .build()
+    }
+
+    fn json_decode<T>(value: &[u8]) -> T
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        serde_json::from_slice(value).expect("Failed to deserialize value")
+    }
+
+    fn create_response(status_code: StatusCode, body: Vec<u8>) -> HttpResponse<'static> {
+        HttpResponse::builder()
+            .with_status_code(status_code)
+            .with_headers(vec![
+                ("content-type".to_string(), "application/json".to_string()),
+                (
+                    "strict-transport-security".to_string(),
+                    "max-age=31536000; includeSubDomains".to_string(),
+                ),
+                ("x-content-type-options".to_string(), "nosniff".to_string()),
+                ("referrer-policy".to_string(), "no-referrer".to_string()),
+                (
+                    "cache-control".to_string(),
+                    "no-store, max-age=0".to_string(),
+                ),
+                ("pragma".to_string(), "no-cache".to_string()),
+            ])
+            .with_body(body)
+            .build()
+    }
+
+    fn create_success_response<T: serde::Serialize>(data: &T) -> HttpResponse<'static> {
+        let body = serde_json::to_vec(data).expect("Failed to serialize response");
+        create_response(StatusCode::OK, body)
+    }
+    
+}
+
+
+
+// src/lib.rs
+use ic_cdk::*;
+use ic_http_certification::{HttpRequest, HttpResponse};
+use core::state::{api_keys::state::state::init_default_admin_apikey, drives::state::state::init_self_drive};
+use std::{cell::RefCell, collections::HashMap};
+
+mod logger;
+mod types;
+mod rest;
+mod core;
+use rest::{router};
+
+#[ic_cdk_macros::init]
+fn init() {
+    debug_log!("Initializing canister...");
+    router::init_routes();
+    init_default_admin_apikey();
+    init_self_drive();  
+}
+
+#[post_upgrade]
+fn post_upgrade() {
+    init();
+}
+
+#[query]
+fn http_request(_req: HttpRequest) -> HttpResponse<'static> {
+    // All requests will be upgraded to update calls
+    HttpResponse::builder()
+        .with_upgrade(true)
+        .build()
+}
+
+#[update]
+fn http_request_update(req: HttpRequest) -> HttpResponse<'static> {
+    router::handle_request(req)
+}

--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -42,3 +42,14 @@ And here are the possible set of events and their corresponding alt_index patter
 - `drive.*` -> `""` empty string
 
 So when a CRUD event happens on a file, we can take the file.id and use it to query against `WEBHOOKS_BY_ALT_INDEX_HASHTABLE` to quickly check in O(1) time if theres a relevant webhook. The limitation is there can only be 1 webhook per resource.
+
+## Default Canister Memory
+
+By default, a drive on ICP mainnet can use the canister itself for filestorage. While convinient, its also slow (10x slower, takes several mins to upload a 60mb video) and expensive ($5/gb/month). However we must still offer it as an option. For this we use the `/directory/raw_upload/*` and `/directory/raw_download/*` routes.
+
+We batch upload files in chunks and canister server reconstructs writing to stable memory continously (hence slow). When we download, we can either:
+
+1. Download by building the file in browser memory as chunks are downloaded. Convinent but memory inefficient, large files can cause lag. Use this for under <100mb.
+2. Download by write-streaming to local computer filesystem which solves the memory efficiency issues, but requires browser permission to access local file directory. Use this for large files >100mb.
+
+The best place to store files is not the canister, its 3rd party integrations like S3, Storj, or local SSD.

--- a/TODO.md
+++ b/TODO.md
@@ -2,12 +2,12 @@
 
 ## Urgent Next
 
-- [x] Migrate & refactor core drive code
-- [ ] Implement in-canister raw file storage
-- [ ] Implement browser-cache raw file storage
-- [ ] Implement local-ssd raw file storage
-- [ ] Implement aws s3 storage
-- [ ] Implement web3storj storage
+- [🔵] Migrate & refactor core drive code --> in front of every POST /directory/action:getFile we need to generate a new raw_url (and potentially also track access_tokens for reuse, at least for public)
+- [🔵] Implement in-canister raw file storage --> has raw_url but only if we add asset-canister functionality
+- [ ] Implement aws s3 storage --> has raw_url but we should be generating on-the-fly urls with temp access token each time
+- [ ] Implement web3storj storage --> has raw_url but we should be generating on-the-fly urls with temp access token each time
+- [ ] Implement browser-cache raw file storage --> no raw_url as it lives in browser cache, only way to access is via p2p webrtc which is a non-persistent link or via torrent link
+- [ ] Implement local-ssd raw file storage --> no raw_url as it lives in local SSD, only way to access is via p2p webrtc which is a non-persistent link or via torrent link
 - [ ] Implement multi-disk storage
 - [ ] Figure out best way to elegantly handle in-canister vs off-canister raw file storage (potentially also `disks` logic holding auth creds)
 - [ ] Write the `directory` REST routes and particularly the file action logic
@@ -24,6 +24,8 @@
 - [ ] Write the `permissions` REST routes (https://youtu.be/5GG-VUvruzE?si=lEC0epAhFlD9-2Bp&t=1165)
 - [ ] Auth check `permissions` on all REST routes
 - [ ] Consider optimistic frontend UI (we should probably use Tanstack Query for React as it handles it for us)
+- [ ] Implement proxied aws/storj where users simply send ETH/SOL to us and we provide storage (might be a scope API key for S3?)
+- [ ] Consider migrating internal state to `ic-stable-structures` for easy upgradeability, otherwise need to implement pre/post upgrade hooks
 
 ## Priority Backlog
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 ## Urgent Next
 
 - [🔵] Migrate & refactor core drive code --> in front of every POST /directory/action:getFile we need to generate a new raw_url (and potentially also track access_tokens for reuse, at least for public)
-- [🔵] Implement in-canister raw file storage --> has raw_url but only if we add asset-canister functionality
+- [🔵] Implement in-canister raw file storage, perhaps we should try a pure asset container? --> has raw_url but only if we add asset-canister functionality
 - [ ] Implement aws s3 storage --> has raw_url but we should be generating on-the-fly urls with temp access token each time
 - [ ] Implement web3storj storage --> has raw_url but we should be generating on-the-fly urls with temp access token each time
 - [ ] Implement browser-cache raw file storage --> no raw_url as it lives in browser cache, only way to access is via p2p webrtc which is a non-persistent link or via torrent link

--- a/prompts/migrate_ephemeral_stable.txt
+++ b/prompts/migrate_ephemeral_stable.txt
@@ -1,0 +1,2 @@
+// OfficeX filesharing app (clone of google drive)
+// where possible, show the code changes as green diffs without the +/- symbols

--- a/src/canisters-official-backend/src/core/state/raw_storage/state.rs
+++ b/src/canisters-official-backend/src/core/state/raw_storage/state.rs
@@ -1,12 +1,80 @@
 // src/core/state/raw_storage/state.rs
+use ic_stable_structures::{
+    memory_manager::{MemoryId, MemoryManager, VirtualMemory},
+    storable::Bound,
+    DefaultMemoryImpl, StableBTreeMap, Storable,
+};
+use std::borrow::Cow;
+use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
-use std::collections::HashMap;
 use crate::core::state::raw_storage::types::{ChunkId, FileChunk};
 
+use super::types::{ChunkIdList, CHUNK_SIZE};
+
+type Memory = VirtualMemory<DefaultMemoryImpl>;
+
+// Define memory IDs for different storage types
+const CHUNKS_MEMORY_ID: MemoryId = MemoryId::new(0);
+const FILE_CHUNKS_MEMORY_ID: MemoryId = MemoryId::new(1);
+const FILE_META_MEMORY_ID: MemoryId = MemoryId::new(2);
+
+// Implement Storable for our types
+impl Storable for ChunkId {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 1024, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::into_writer(&self.0, &mut bytes).expect("Failed to serialize ChunkId");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        let string: String = ciborium::from_reader(&bytes[..]).expect("Failed to deserialize ChunkId");
+        ChunkId(string)
+    }
+}
+
+impl Storable for FileChunk {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: CHUNK_SIZE as u32 + 1024, // Base chunk size plus metadata overhead
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::into_writer(&self, &mut bytes).expect("Failed to serialize FileChunk");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::from_reader(&bytes[..]).expect("Failed to deserialize FileChunk")
+    }
+}
+
 thread_local! {
-    pub static CHUNKS: RefCell<HashMap<ChunkId, FileChunk>> = RefCell::new(HashMap::new());
-    pub static FILE_CHUNKS: RefCell<HashMap<String, Vec<ChunkId>>> = RefCell::new(HashMap::new());
-    pub static FILE_META: RefCell<HashMap<String, String>> = RefCell::new(HashMap::new());
+    pub(crate) static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = 
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+
+    pub(crate) static CHUNKS: RefCell<StableBTreeMap<ChunkId, FileChunk, Memory>> = RefCell::new(
+        StableBTreeMap::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(CHUNKS_MEMORY_ID))
+        )
+    );
+
+    pub(crate) static FILE_CHUNKS: RefCell<StableBTreeMap<String, ChunkIdList, Memory>> = RefCell::new(
+        StableBTreeMap::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(FILE_CHUNKS_MEMORY_ID))
+        )
+    );
+
+    pub(crate) static FILE_META: RefCell<StableBTreeMap<String, String, Memory>> = RefCell::new(
+        StableBTreeMap::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(FILE_META_MEMORY_ID))
+        )
+    );
 }
 
 pub fn store_chunk(chunk: FileChunk) {
@@ -16,28 +84,30 @@ pub fn store_chunk(chunk: FileChunk) {
 
     FILE_CHUNKS.with(|file_chunks| {
         let mut map = file_chunks.borrow_mut();
-        map.entry(chunk.file_id.clone())
-           .or_insert_with(Vec::new)
-           .push(chunk.id);
+        let existing_chunks = map.get(&chunk.file_id)
+            .map(|list| list.0.clone())
+            .unwrap_or_default();
+        let mut new_chunks = existing_chunks;
+        new_chunks.push(chunk.id.clone());
+        map.insert(chunk.file_id.clone(), ChunkIdList(new_chunks));
     });
 }
 
 pub fn get_chunk(chunk_id: &ChunkId) -> Option<FileChunk> {
-    CHUNKS.with(|chunks| chunks.borrow().get(chunk_id).cloned())
+    CHUNKS.with(|chunks| chunks.borrow().get(chunk_id))
 }
 
 pub fn get_file_chunks(file_id: &str) -> Vec<FileChunk> {
     FILE_CHUNKS.with(|file_chunks| {
-        if let Some(chunk_ids) = file_chunks.borrow().get(file_id) {
-            chunk_ids.iter()
-                    .filter_map(|id| get_chunk(id))
-                    .collect()
+        if let Some(chunk_list) = file_chunks.borrow().get(&file_id.to_string()) {
+            chunk_list.0.iter()
+                .filter_map(|id| get_chunk(id))
+                .collect()
         } else {
             Vec::new()
         }
     })
 }
-
 
 pub fn store_filename(file_id: &str, filename: &str) {
     FILE_META.with(|fmeta| {

--- a/src/canisters-official-backend/src/rest/directory/handler.rs
+++ b/src/canisters-official-backend/src/rest/directory/handler.rs
@@ -6,6 +6,7 @@ pub mod directorys_handlers {
         core::{api::{drive::drive::fetch_files_at_folder_path, uuid::generate_unique_id}, state::{directory::{}, drives::state::state::OWNER_ID, raw_storage::{state::{get_file_chunks, store_chunk, store_filename, FILE_META}, types::{ChunkId, FileChunk, CHUNK_SIZE}}}}, debug_log, rest::{auth::{authenticate_request, create_auth_error_response, create_raw_upload_error_response}, directory::types::{CompleteUploadRequest, CompleteUploadResponse, DirectoryActionRequest, DirectoryActionResponse, DirectoryListResponse, ErrorResponse, FileMetadataResponse, ListDirectoryRequest, UploadChunkRequest, UploadChunkResponse}}, 
         
     };
+    
     use ic_http_certification::{HttpRequest, HttpResponse, StatusCode};
     use matchit::Params;
     use serde::Deserialize;
@@ -226,7 +227,7 @@ pub mod directorys_handlers {
         let filename: String = FILE_META.with(|map| 
             map.borrow()
                 .get(&file_id.to_string())
-                .cloned()
+                .clone()  // Change cloned() to clone()
         ).unwrap_or_else(|| "unknown.bin".to_string());
 
         // Create a JSON response with metadata


### PR DESCRIPTION
- working simple implementation of icp http canisters for storage
- uses persistent stable structures 