### PR TITLE
Redacted contacts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,8 @@
 
 ## Urgent Next
 
+- [ ] For every route, apply redaction (as we go along)
+- [ ] Audit types for file/folders, some missing disk_enum, canister_id maybe replace with endpoint_url, etc
 - [ ] Consider whether we need a global index on web2 for all containers in world history (that way we can easily also catch canisters on https://api.officex.app/v1/{any_drive_id}/route)
 - [x] Write code for import profile via API Key, should work with placeholder contact and/or employer owned seedphrase
 - [x] Setup multi-organization switch with prefixed cache, cookies, indexdb, etc
@@ -119,3 +121,4 @@
 - [x] Add support for contacts.seed_phrase for employer owned user accounts (employers can just give api_keys to users)
 - [x] Write code for self factory spawn new organizations
 - [x] Setup factory to spawn Drive canisters with owner set
+- [x] Add redaction to all route types

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,6 @@
 
 ## Urgent Next
 
-- [🔵] Write code for self factory spawn new organizations
 - [ ] Consider whether we need a global index on web2 for all containers in world history (that way we can easily also catch canisters on https://api.officex.app/v1/{any_drive_id}/route)
 - [x] Write code for import profile via API Key, should work with placeholder contact and/or employer owned seedphrase
 - [x] Setup multi-organization switch with prefixed cache, cookies, indexdb, etc
@@ -23,7 +22,6 @@
 
 ## Near Future
 
-- [ ] Setup factory to spawn Drive canisters with owner set
 - [ ] Test out webapp http server
 - [ ] Test out webapp torrenting
 - [ ] Consider optimistic frontend UI (we should probably use Tanstack Query for React as it handles it for us)
@@ -32,6 +30,7 @@
 
 ## Priority Backlog
 
+- [ ] Graduating canisters via state sync import (from offline to web2 to web3)
 - [ ] Test whether the s3/storj copy operation works (does raw_storage actually get duplicated?)
 - [ ] Implement browser-cache raw file storage --> no raw_url as it lives in browser cache, only way to access is via p2p webrtc which is a non-persistent link or via torrent link
 - [ ] Implement local-ssd raw file storage --> no raw_url as it lives in local SSD, only way to access is via p2p webrtc which is a non-persistent link or via torrent link
@@ -118,3 +117,5 @@
 - [x] Implement userid superswap, with webhook
 - [x] Refactor Contacts to support placeholder contacts, which requires refactor ContactID as primary key, not UserID. This has implications on how permissions work, we still want every user to be an ICP public address.(which i think we still can, since Contacts are simply a wrapper around public address string as user). --> solution is superswap userid (keep contacts.id as userid, add new route to globally swap user_id primary key to new user_id)
 - [x] Add support for contacts.seed_phrase for employer owned user accounts (employers can just give api_keys to users)
+- [x] Write code for self factory spawn new organizations
+- [x] Setup factory to spawn Drive canisters with owner set

--- a/src/canisters-factory-backend/canisters-factory-backend.did
+++ b/src/canisters-factory-backend/canisters-factory-backend.did
@@ -1,6 +1,6 @@
 type InitArgs = record {
   owner : text;
-  nickname : opt text;
+  title : opt text;
   spawn_redeem_code : opt text;
 };
 

--- a/src/canisters-factory-backend/src/rest/giftcards/handler.rs
+++ b/src/canisters-factory-backend/src/rest/giftcards/handler.rs
@@ -595,7 +595,7 @@ pub mod giftcards_handlers {
     // Helper function to deploy a drive canister
     async fn deploy_drive_canister(
         owner_icp_principal: String, 
-        nickname: Option<String>, 
+        title: Option<String>, 
         spawn_redeem_code: String,
         note: Option<String>,
         cycles: u64
@@ -640,7 +640,7 @@ pub mod giftcards_handlers {
                 // Create SpawnInitArgs for the canister
                 let init_args = SpawnInitArgs {
                     owner: owner_icp_principal,
-                    nickname,
+                    title,
                     note,
                     spawn_redeem_code: Some(spawn_redeem_code),
                 };

--- a/src/canisters-factory-backend/src/rest/giftcards/types.rs
+++ b/src/canisters-factory-backend/src/rest/giftcards/types.rs
@@ -255,7 +255,7 @@ impl RedeemGiftcardData {
             }
         };
 
-        // Validate nickname if provided
+        // Validate title if provided
         if let Some(organization_name) = &self.organization_name {
             if organization_name.trim().is_empty() {
                 return Err(ValidationError {
@@ -290,7 +290,7 @@ pub type RedeemGiftcardResponse<'a> = ApiResponse<'a, RedeemGiftcardResult>;
 #[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct SpawnInitArgs {
     pub owner: String, // Plain string for simplicity, really should be ICPPrincipalString
-    pub nickname: Option<String>,
+    pub title: Option<String>,
     pub note: Option<String>,
     pub spawn_redeem_code: Option<String>,
 }

--- a/src/canisters-official-backend/src/core/state/contacts/state.rs
+++ b/src/canisters-official-backend/src/core/state/contacts/state.rs
@@ -25,7 +25,9 @@ pub mod state {
 
         let default_contact = Contact {
             id: owner_id.clone(),
-            nickname: "Anonymous Owner".to_string(),
+            name: "Anonymous Owner".to_string(),
+            email: None,
+            webhook_url: None,
             public_note: "Default system owner".to_string(),
             private_note: None,
             evm_public_address: "".to_string(), // Empty string as placeholder

--- a/src/canisters-official-backend/src/core/state/contacts/types.rs
+++ b/src/canisters-official-backend/src/core/state/contacts/types.rs
@@ -2,13 +2,15 @@
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
 
-use crate::core::{state::{drives::types::{ExternalID, ExternalPayload}, tags::types::TagStringValue, teams::types::TeamID}, types::{ICPPrincipalString, PublicKeyICP, UserID}};
+use crate::core::{api::permissions::system::check_system_permissions, state::{drives::{state::state::OWNER_ID, types::{ExternalID, ExternalPayload}}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}, tags::types::{redact_tag, TagStringValue}, teams::types::TeamID}, types::{ICPPrincipalString, PublicKeyICP, UserID}};
 
 
 #[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
 pub struct Contact {
     pub id: UserID,
-    pub nickname: String,
+    pub name: String,
+    pub email: Option<String>,
+    pub webhook_url: Option<String>, // acts as an alternative to email, separate from main webhook system
     pub public_note: String,
     pub private_note: Option<String>,
     pub evm_public_address: String,
@@ -21,4 +23,49 @@ pub struct Contact {
     pub external_payload: Option<ExternalPayload>,
     pub from_placeholder_user_id: Option<UserID>,
     pub redeem_token: Option<String>,
+}
+
+impl Contact {
+    pub fn redacted(&self, user_id: &UserID) -> Self {
+        let mut redacted = self.clone();
+
+        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let is_owned = *user_id != self.id;
+        let table_permissions = check_system_permissions(
+            SystemResourceID::Table(SystemTableEnum::Contacts),
+            PermissionGranteeID::User(user_id.clone())
+        );
+        let resource_id = SystemResourceID::Record(SystemRecordIDEnum::User(self.id.clone().to_string()));
+        let permissions = check_system_permissions(
+            resource_id,
+            PermissionGranteeID::User(user_id.clone())
+        );
+        let has_edit_permissions = permissions.contains(&SystemPermissionType::Update) || table_permissions.contains(&SystemPermissionType::Update);
+
+        // Most sensitive
+        if !is_owner {
+            redacted.seed_phrase = None;
+
+            // 2nd most sensitive
+            if !has_edit_permissions {
+                redacted.redeem_token = None;
+                redacted.private_note = None;
+
+                // 3rd most sensitive
+                if !is_owned {
+                    redacted.webhook_url = None;
+                    redacted.from_placeholder_user_id = None;
+                }
+            }
+        }
+        // Filter tags
+        redacted.tags = match is_owner {
+            true => redacted.tags,
+            false => redacted.tags.iter()
+            .filter_map(|tag| redact_tag(tag.clone(), user_id.clone()))
+            .collect()
+        };
+        
+        redacted
+    }
 }

--- a/src/canisters-official-backend/src/core/state/contacts/types.rs
+++ b/src/canisters-official-backend/src/core/state/contacts/types.rs
@@ -30,7 +30,7 @@ impl Contact {
         let mut redacted = self.clone();
 
         let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
-        let is_owned = *user_id != self.id;
+        let is_owned = *user_id == self.id;
         let table_permissions = check_system_permissions(
             SystemResourceID::Table(SystemTableEnum::Contacts),
             PermissionGranteeID::User(user_id.clone())

--- a/src/canisters-official-backend/src/core/state/search/state.rs
+++ b/src/canisters-official-backend/src/core/state/search/state.rs
@@ -158,7 +158,7 @@ pub mod state {
                 let search_string = format!(
                     "{}|{}|{}|{}",
                     contact_id.0,
-                    contact.nickname,
+                    contact.name,
                     contact.icp_principal.0.0,
                     contact.evm_public_address
                 );
@@ -570,7 +570,7 @@ pub mod state {
                 
                 CONTACTS_BY_ID_HASHTABLE.with(|contacts| {
                     if let Some(contact) = contacts.borrow().get(user_id) {
-                        title = contact.nickname.clone();
+                        title = contact.name.clone();
                         preview = contact.icp_principal.0.0.clone();
                     }
                 });

--- a/src/canisters-official-backend/src/core/state/team_invites/types.rs
+++ b/src/canisters-official-backend/src/core/state/team_invites/types.rs
@@ -3,8 +3,11 @@ use std::fmt;
 // src/core/state/team_invites/types.rs
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
+use crate::core::api::permissions::system::check_system_permissions;
+use crate::core::state::drives::state::state::OWNER_ID;
 use crate::core::state::drives::types::{ExternalID, ExternalPayload};
-use crate::core::state::tags::types::TagStringValue;
+use crate::core::state::permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum};
+use crate::core::state::tags::types::{redact_tag, TagStringValue};
 use crate::core::state::teams::types::TeamID;
 use crate::core::types::{UserID};
 
@@ -16,7 +19,6 @@ impl fmt::Display for TeamInviteID {
         write!(f, "{}", self.0)
     }
 }
-
 
 #[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
 pub struct Team_Invite {
@@ -34,6 +36,35 @@ pub struct Team_Invite {
     pub tags: Vec<TagStringValue>,
     pub external_id: Option<ExternalID>,
     pub external_payload: Option<ExternalPayload>,
+}
+
+impl Team_Invite {
+    pub fn redacted(&self, user_id: &UserID) -> Self {
+        let mut redacted = self.clone();
+
+        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        // let is_owned = self.inviter_id == *user_id || self.invitee_id == TeamInviteeID::User(user_id.clone());
+        // let table_permissions = check_system_permissions(
+        //     SystemResourceID::Table(SystemTableEnum::Teams),
+        //     PermissionGranteeID::User(user_id.clone())
+        // );
+        // let resource_id = SystemResourceID::Record(SystemRecordIDEnum::User(self.id.clone().to_string()));
+        // let permissions = check_system_permissions(
+        //     resource_id,
+        //     PermissionGranteeID::User(user_id.clone())
+        // );
+        // let has_edit_permissions = permissions.contains(&SystemPermissionType::Update) || table_permissions.contains(&SystemPermissionType::Update);
+
+        // Filter tags
+        redacted.tags = match is_owner {
+            true => redacted.tags,
+            false => redacted.tags.iter()
+            .filter_map(|tag| redact_tag(tag.clone(), user_id.clone()))
+            .collect()
+        };
+        
+        redacted
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, SerdeDiff)]

--- a/src/canisters-official-backend/src/core/state/teams/types.rs
+++ b/src/canisters-official-backend/src/core/state/teams/types.rs
@@ -2,10 +2,11 @@
 use serde::{Serialize, Deserialize};
 use std::fmt;
 use crate::core::{
-    state::{drives::types::{DriveID, DriveRESTUrlEndpoint, ExternalID, ExternalPayload}, tags::types::TagStringValue, team_invites::types::TeamInviteID},
-    types::UserID
+    api::permissions::system::check_system_permissions, state::{drives::{state::state::OWNER_ID, types::{DriveID, DriveRESTUrlEndpoint, ExternalID, ExternalPayload}}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}, tags::types::{redact_tag, TagStringValue}, team_invites::types::TeamInviteID}, types::UserID
 };
 use serde_diff::{SerdeDiff};
+
+use super::state::state::is_team_admin;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
 pub struct TeamID(pub String);
@@ -26,6 +27,44 @@ pub struct Team {
     pub tags: Vec<TagStringValue>,
     pub external_id: Option<ExternalID>,
     pub external_payload: Option<ExternalPayload>,
+}
+impl Team {
+    pub fn redacted(&self, user_id: &UserID) -> Self {
+        let mut redacted = self.clone();
+
+        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let table_permissions = check_system_permissions(
+            SystemResourceID::Table(SystemTableEnum::Teams),
+            PermissionGranteeID::User(user_id.clone())
+        );
+        let resource_id = SystemResourceID::Record(SystemRecordIDEnum::User(self.id.clone().to_string()));
+        let permissions = check_system_permissions(
+            resource_id,
+            PermissionGranteeID::User(user_id.clone())
+        );
+        let has_edit_permissions = permissions.contains(&SystemPermissionType::Update) || table_permissions.contains(&SystemPermissionType::Update);
+        let is_team_admin = is_team_admin(user_id, &self.id);
+
+        // Most sensitive
+        if !is_owner {
+
+            // 2nd most sensitive
+            if !has_edit_permissions && !is_team_admin {
+                redacted.admin_invites = vec![];
+                redacted.member_invites = vec![];
+                redacted.private_note = None;
+            }
+        }
+        // Filter tags
+        redacted.tags = match is_owner {
+            true => redacted.tags,
+            false => redacted.tags.iter()
+            .filter_map(|tag| redact_tag(tag.clone(), user_id.clone()))
+            .collect()
+        };
+        
+        redacted
+    }
 }
 
 // Implement Display for TeamID

--- a/src/canisters-official-backend/src/rest/api_keys/handler.rs
+++ b/src/canisters-official-backend/src/rest/api_keys/handler.rs
@@ -14,9 +14,6 @@ pub mod apikeys_handlers {
         completed: Option<bool>,
     }
 
-    
-
-
     pub async fn get_apikey_handler<'a, 'k, 'v>(request: &'a HttpRequest<'a>, params: &'a Params<'k, 'v>) -> HttpResponse<'static> {
 
 
@@ -69,9 +66,10 @@ pub mod apikeys_handlers {
                 //         requested_id
                 //     ).to_string())
                 // );
+                let redacted_key = key.clone().redacted(&requester_api_key.user_id);
                 create_response(
                     StatusCode::OK,
-                    GetApiKeyResponse::ok(&key).encode()
+                    GetApiKeyResponse::ok(&redacted_key).encode()
                 )
             },
             None => create_response(
@@ -130,6 +128,7 @@ pub mod apikeys_handlers {
                         .map(|key| ApiKeyHidden::from(key.clone()))
                         .collect()
                 });
+                let redacted_api_keys = api_keys.clone().iter().map(|key| key.redacted(&requester_api_key.user_id)).collect();
 
                 // snapshot_poststate(prestate, Some(
                 //     format!("{}: List API Keys", requester_api_key.user_id).to_string())
@@ -137,7 +136,7 @@ pub mod apikeys_handlers {
 
                 create_response(
                     StatusCode::OK,
-                    ListApiKeysResponse::ok(&api_keys).encode()
+                    ListApiKeysResponse::ok(&redacted_api_keys).encode()
                 )
             },
             None => create_response(
@@ -246,9 +245,11 @@ pub mod apikeys_handlers {
                         ).to_string())
                     );
 
+                    let redacted_key = new_api_key.clone().redacted(&requester_api_key.user_id);
+
                     create_response(
                         StatusCode::OK,
-                        CreateApiKeyResponse::ok(&new_api_key).encode()
+                        CreateApiKeyResponse::ok(&redacted_key).encode()
                     )  
                 },
                 UpsertApiKeyRequestBody::Update(update_req) => {
@@ -330,9 +331,10 @@ pub mod apikeys_handlers {
                                     api_key.id
                                 ).to_string())
                             );
+                            let redacted_key = key.clone().redacted(&requester_api_key.user_id);
                             create_response(
                                 StatusCode::OK,
-                                UpdateApiKeyResponse::ok(&key).encode()
+                                UpdateApiKeyResponse::ok(&redacted_key).encode()
                             )
                         },
                         None => create_response(

--- a/src/canisters-official-backend/src/rest/organization/handler.rs
+++ b/src/canisters-official-backend/src/rest/organization/handler.rs
@@ -670,7 +670,7 @@ pub mod drives_handlers {
         let nickname = CONTACTS_BY_ID_HASHTABLE.with(|store| {
             store.borrow()
                 .get(&requester_api_key.user_id)
-                .map(|contact| contact.nickname.clone())
+                .map(|contact| contact.name.clone())
                 .unwrap_or_else(|| String::new())
         });
         


### PR DESCRIPTION
- add redaction helper functions to all route types
- implemented redaction on `/contacts/*` routes as reference
- all other routes we can apply redaction as we go along