### PR TITLE
stable upgrades attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ dfx canister create canisters-factory-backend && dfx build && dfx deploy canis
 or upgrade specific canister in dev:
 
 ```sh
-$ dfx build canisters-official-backend && dfx canister install bw4dl-smaaa-aaaaa-qaacq-cai --mode upgrade --argument "(opt record { owner = \"$(dfx identity get-principal)\" })" --wasm target/wasm32-unknown-unknown/release/canisters_official_backend.wasm
+$ dfx build canisters-official-backend && dfx canister install canisters-official-backend --mode upgrade --argument "(opt record { owner = \"$(dfx identity get-principal)\" })" --wasm target/wasm32-unknown-unknown/release/canisters_official_backend.wasm
 ```
 
 or standalone factory in prod:

--- a/TODO.md
+++ b/TODO.md
@@ -7,8 +7,6 @@
 
 ## Urgent Next
 
-- [🔵] Figure out how to cleanly update past Drive canisters spawned from factory, including factory canister and revising what else should be in snapshot_state
-
 - [🔵] Fix superswap user to also handle permissions updating
 - [ ] Audit the list handlers and inputs to be string based, not rust enum based (might need to audit all route types even)
 
@@ -157,3 +155,4 @@
 - [x] Implement privacy filesystem `disk/shared_with_me_virtual_folder/shortcut123` where "shared_with_me_virtual_folder" is at root level ui-only folder with shortcuts to all the files/folders a user has access to. requires keeping track of user<>directorypermission perhaps using `DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE` --> in the end, we just let every disk have its own "shared with me"
 - [x] Deposit Gas giftcard functionality in factory, and factory default storjweb3 bucket
 - [x] Search functionality fix
+- [x] Figure out how to cleanly update past Drive canisters spawned from factory, including factory canister and revising what else should be in snapshot_state

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,8 @@
 
 ## Urgent Next
 
+- [🔵] Figure out how to cleanly update past Drive canisters spawned from factory, including factory canister and revising what else should be in snapshot_state
+
 - [🔵] Fix superswap user to also handle permissions updating
 - [ ] Audit the list handlers and inputs to be string based, not rust enum based (might need to audit all route types even)
 
@@ -42,7 +44,6 @@
 
 ## Backlog
 
-- [ ] Figure out how to cleanly update past Drive canisters spawned from factory
 - [ ] Consider migrating internal state to `ic-stable-structures` for easy upgradeability, otherwise need to implement pre/post upgrade hooks
 - [ ] Migrate S3 secret key storage to safer VET keys https://x.com/DFINITYDev/status/1893198318781513878
 - [ ] Implement proxied aws/storj where users simply send ETH/SOL to us and we provide storage (might be a scope API key for S3?)

--- a/src/canisters-factory-backend/src/core/state/api_keys/state.rs
+++ b/src/canisters-factory-backend/src/core/state/api_keys/state.rs
@@ -1,37 +1,92 @@
 
+// factory repo
 // src/core/state/api_keys/state.rs
 pub mod state {
     use std::cell::{Cell, RefCell};
     use std::collections::HashMap;
+    use ic_stable_structures::memory_manager::MemoryId;
+    use ic_stable_structures::{StableBTreeMap, DefaultMemoryImpl, StableVec};
+
+    use crate::core::state::api_keys::types::ApiKeyIDList;
+    use crate::MEMORY_MANAGER;
     use crate::{core::{api::uuid::{generate_api_key, generate_uuidv4}, state::{api_keys::types::{ApiKey, ApiKeyID, ApiKeyValue}, giftcards_spawnorg::state::state::OWNER_ID}, types::{IDPrefix, UserID}}, debug_log};
+
+    type Memory = ic_stable_structures::memory_manager::VirtualMemory<DefaultMemoryImpl>;
+    pub const APIKEYS_MEMORY_ID: MemoryId = MemoryId::new(1);
+    pub const APIKEYS_BY_VALUE_MEMORY_ID: MemoryId = MemoryId::new(2);
+    pub const USERS_APIKEYS_MEMORY_ID: MemoryId = MemoryId::new(3);
+    pub const APIKEYS_BY_HISTORY_MEMORY_ID: MemoryId = MemoryId::new(4);
 
     thread_local! {
         // users pass in api key value, we O(1) lookup the api key id + O(1) lookup the api key
-        pub(crate) static APIKEYS_BY_VALUE_HASHTABLE: RefCell<HashMap<ApiKeyValue, ApiKeyID>> = RefCell::new(HashMap::new());
+        pub(crate) static APIKEYS_BY_VALUE_HASHTABLE: RefCell<StableBTreeMap<ApiKeyValue, ApiKeyID, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(APIKEYS_BY_VALUE_MEMORY_ID))
+            )
+        );
         // default is to use the api key id to lookup the api key
-        pub(crate) static APIKEYS_BY_ID_HASHTABLE: RefCell<HashMap<ApiKeyID, ApiKey>> = RefCell::new(HashMap::new());
+        pub(crate) static APIKEYS_BY_ID_HASHTABLE: RefCell<StableBTreeMap<ApiKeyID, ApiKey, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(APIKEYS_MEMORY_ID))
+            )
+        );
         // track in hashtable users list of ApiKeyIDs
-        pub(crate) static USERS_APIKEYS_HASHTABLE: RefCell<HashMap<UserID, Vec<ApiKeyID>>> = RefCell::new(HashMap::new());
-        // track in vector the history of api keys
-        pub(crate) static APIKEYS_BY_HISTORY: RefCell<Vec<ApiKeyID>> = RefCell::new(Vec::new());
+        pub(crate) static USERS_APIKEYS_HASHTABLE: RefCell<StableBTreeMap<UserID, ApiKeyIDList, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(USERS_APIKEYS_MEMORY_ID))
+            )
+        );
+        // track in vector the history of api keys, similar to CONTACTS_BY_TIME_LIST
+        pub(crate) static APIKEYS_BY_HISTORY: RefCell<StableVec<ApiKeyID, Memory>> = RefCell::new(
+            StableVec::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(APIKEYS_BY_HISTORY_MEMORY_ID))
+            ).expect("Failed to initialize APIKEYS_BY_HISTORY")
+        );
     }
 
     // Helper functions to get debug string representations
     pub fn debug_apikeys_by_value() -> String {
         APIKEYS_BY_VALUE_HASHTABLE.with(|map| {
-            format!("{:#?}", map.borrow())
+            let map_ref = map.borrow();
+            let mut entries = Vec::new();
+            
+            for key in map_ref.iter().map(|(k, _)| k) {
+                if let Some(value) = map_ref.get(&key) {
+                    entries.push(format!("{:?} => {:?}", key, value));
+                }
+            }
+            
+            format!("{{\n  {}\n}}", entries.join(",\n  "))
         })
     }
 
     pub fn debug_apikeys_by_id() -> String {
         APIKEYS_BY_ID_HASHTABLE.with(|map| {
-            format!("{:#?}", map.borrow())
+            let map_ref = map.borrow();
+            let mut entries = Vec::new();
+            
+            for key in map_ref.iter().map(|(k, _)| k) {
+                if let Some(value) = map_ref.get(&key) {
+                    entries.push(format!("{:?} => {:?}", key, value));
+                }
+            }
+            
+            format!("{{\n  {}\n}}", entries.join(",\n  "))
         })
     }
 
     pub fn debug_users_apikeys() -> String {
         USERS_APIKEYS_HASHTABLE.with(|map| {
-            format!("{:#?}", map.borrow())
+            let map_ref = map.borrow();
+            let mut entries = Vec::new();
+            
+            for key in map_ref.iter().map(|(k, _)| k) {
+                if let Some(value) = map_ref.get(&key) {
+                    entries.push(format!("{:?} => {:?}", key, value));
+                }
+            }
+            
+            format!("{{\n  {}\n}}", entries.join(",\n  "))
         })
     }
 
@@ -52,7 +107,7 @@ pub mod state {
         let default_key = ApiKey {
             id: ApiKeyID(generate_uuidv4(IDPrefix::ApiKey)),
             value: ApiKeyValue(generate_api_key()),
-            user_id: OWNER_ID.with(|id| id.borrow().clone()),
+            user_id: OWNER_ID.with(|id| id.borrow().get().clone()),
             name: "Default Admin Key".to_string(),
             created_at: ic_cdk::api::time(),
             expires_at: -1,
@@ -70,11 +125,12 @@ pub mod state {
         });
 
         USERS_APIKEYS_HASHTABLE.with(|map| {
-            map.borrow_mut().insert(default_key.user_id.clone(), vec![default_key.id.clone()]);
+            let key_list = ApiKeyIDList::with_key(default_key.id.clone());
+            map.borrow_mut().insert(default_key.user_id.clone(), key_list);
         });
 
-        APIKEYS_BY_HISTORY.with(|vec| {
-            vec.borrow_mut().insert(0, default_key.id.clone());
+        APIKEYS_BY_HISTORY.with(|list| {
+            list.borrow_mut().push(&default_key.id);
         });
     }
 }

--- a/src/canisters-factory-backend/src/core/state/api_keys/types.rs
+++ b/src/canisters-factory-backend/src/core/state/api_keys/types.rs
@@ -1,12 +1,32 @@
 
+use ic_stable_structures::{storable::Bound, Storable};
 // src/core/state/api_keys/types.rs
 use serde_diff::{Diff, SerdeDiff};
 use serde::{Deserialize, Serialize};
 use crate::core::{types::UserID};
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
 pub struct ApiKeyID(pub String);
+
+impl Storable for ApiKeyID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize ApiKeyID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize ApiKeyID")
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
 pub struct ApiKeyValue(pub String);

--- a/src/canisters-factory-backend/src/core/state/api_keys/types.rs
+++ b/src/canisters-factory-backend/src/core/state/api_keys/types.rs
@@ -1,12 +1,14 @@
-
-use ic_stable_structures::{storable::Bound, Storable};
+// factory repo
 // src/core/state/api_keys/types.rs
+
+use candid::CandidType;
+use ic_stable_structures::{storable::Bound, Storable};
 use serde_diff::{Diff, SerdeDiff};
 use serde::{Deserialize, Serialize};
 use crate::core::{types::UserID};
 use std::{borrow::Cow, fmt};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, PartialOrd, Ord, CandidType)]
 pub struct ApiKeyID(pub String);
 
 impl Storable for ApiKeyID {
@@ -28,8 +30,27 @@ impl Storable for ApiKeyID {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, PartialOrd, Ord)]
 pub struct ApiKeyValue(pub String);
+
+impl Storable for ApiKeyValue {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 4, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize ApiKeyValue");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize ApiKeyValue")
+    }
+}
 
 
 // Implement Display for ApiKey
@@ -49,6 +70,25 @@ pub struct ApiKey {
     pub created_at: u64, 
     pub expires_at: i64, 
     pub is_revoked: bool,
+}
+
+impl Storable for ApiKey {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize ApiKey");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize ApiKey")
+    }
 }
 
 
@@ -110,4 +150,72 @@ pub struct SignatureAuthChallenge {
     pub drive_canister_id: String,
     pub self_auth_principal: Vec<u8>,
     pub canonical_principal: String,
+}
+
+
+
+#[derive(Clone, Debug, CandidType, Deserialize, Serialize, SerdeDiff)]
+pub struct ApiKeyIDList {
+    pub keys: Vec<ApiKeyID>,
+}
+impl ApiKeyIDList {
+    pub fn new() -> Self {
+        Self { keys: Vec::new() }
+    }
+    
+    pub fn with_key(key_id: ApiKeyID) -> Self {
+        Self { keys: vec![key_id] }
+    }
+    
+    pub fn add(&mut self, key_id: ApiKeyID) {
+        self.keys.push(key_id);
+    }
+    
+    pub fn remove(&mut self, key_id: &ApiKeyID) -> bool {
+        if let Some(pos) = self.keys.iter().position(|k| k == key_id) {
+            self.keys.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+    
+    // Add iter method to satisfy the error in handler.rs
+    pub fn iter(&self) -> impl Iterator<Item = &ApiKeyID> {
+        self.keys.iter()
+    }
+    
+    // Check if the list is empty
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+}
+
+// Implement conversion between Vec<ApiKeyID> and ApiKeyIDList
+impl From<Vec<ApiKeyID>> for ApiKeyIDList {
+    fn from(keys: Vec<ApiKeyID>) -> Self {
+        Self { keys }
+    }
+}
+
+impl From<ApiKeyIDList> for Vec<ApiKeyID> {
+    fn from(list: ApiKeyIDList) -> Self {
+        list.keys
+    }
+}
+// Implement Storable for ApiKeyIDList
+impl Storable for ApiKeyIDList {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 1024 * 4, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = candid::encode_one(self).unwrap();
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).unwrap()
+    }
 }

--- a/src/canisters-factory-backend/src/core/state/giftcards_refuel/state.rs
+++ b/src/canisters-factory-backend/src/core/state/giftcards_refuel/state.rs
@@ -3,21 +3,59 @@
 pub mod state {
     use std::cell::RefCell;
     use std::collections::HashMap;
-    use crate::core::state::giftcards_refuel::types::FactoryRefuelHistoryRecord;
+    use ic_stable_structures::memory_manager::MemoryId;
+    use ic_stable_structures::{DefaultMemoryImpl,StableBTreeMap,StableVec};
+
+    use crate::core::state::giftcards_refuel::types::{FactoryRefuelHistoryRecord, GiftcardRefuelIDVec};
     use crate::core::state::giftcards_spawnorg::types::DriveID;
     use crate::core::state::giftcards_refuel::types::GiftcardRefuelID;
     use crate::core::state::giftcards_refuel::types::GiftcardRefuel;
 
     use crate::core::types::{UserID};
+    use crate::MEMORY_MANAGER;
     
+
+    type Memory = ic_stable_structures::memory_manager::VirtualMemory<DefaultMemoryImpl>;
+    
+    // Define memory IDs for each storage
+    pub const DEPLOYMENTS_BY_GIFTCARD_REFUEL_ID_MEMORY_ID: MemoryId = MemoryId::new(5);
+    pub const HISTORICAL_GIFTCARDS_REFUELS_MEMORY_ID: MemoryId = MemoryId::new(6);
+    pub const DRIVE_TO_GIFTCARD_REFUEL_MEMORY_ID: MemoryId = MemoryId::new(7);
+    pub const USER_TO_GIFTCARDS_REFUEL_MEMORY_ID: MemoryId = MemoryId::new(8);
+    pub const GIFTCARD_REFUEL_BY_ID_MEMORY_ID: MemoryId = MemoryId::new(9);
 
     thread_local! { 
         // GiftcardRefuel and deployment tracking
-        pub(crate) static DEPLOYMENTS_BY_GIFTCARD_REFUEL_ID: RefCell<HashMap<GiftcardRefuelID, FactoryRefuelHistoryRecord>> = RefCell::new(HashMap::new());
-        pub(crate) static HISTORICAL_GIFTCARDS_REFUELS: RefCell<Vec<GiftcardRefuelID>> = RefCell::new(Vec::new());
-        pub(crate) static DRIVE_TO_GIFTCARD_REFUEL_HASHTABLE: RefCell<HashMap<DriveID, GiftcardRefuelID>> = RefCell::new(HashMap::new());
-        pub(crate) static USER_TO_GIFTCARDS_REFUEL_HASHTABLE: RefCell<HashMap<UserID, Vec<GiftcardRefuelID>>> = RefCell::new(HashMap::new());
-        pub(crate) static GIFTCARD_REFUEL_BY_ID: RefCell<HashMap<GiftcardRefuelID, GiftcardRefuel>> = RefCell::new(HashMap::new());
+        pub(crate) static DEPLOYMENTS_BY_GIFTCARD_REFUEL_ID: RefCell<StableBTreeMap<GiftcardRefuelID, FactoryRefuelHistoryRecord, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(DEPLOYMENTS_BY_GIFTCARD_REFUEL_ID_MEMORY_ID))
+            )
+        );
+        
+        pub(crate) static HISTORICAL_GIFTCARDS_REFUELS: RefCell<StableVec<GiftcardRefuelID, Memory>> = RefCell::new(
+            StableVec::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(HISTORICAL_GIFTCARDS_REFUELS_MEMORY_ID))
+            ).expect("Failed to initialize HISTORICAL_GIFTCARDS_REFUELS")
+        );
+        
+        pub(crate) static DRIVE_TO_GIFTCARD_REFUEL_HASHTABLE: RefCell<StableBTreeMap<DriveID, GiftcardRefuelID, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(DRIVE_TO_GIFTCARD_REFUEL_MEMORY_ID))
+            )
+        );
+        
+        // For the UserID to Vec<GiftcardRefuelID> mapping, we need a custom type similar to StringVec in the reference
+        pub(crate) static USER_TO_GIFTCARDS_REFUEL_HASHTABLE: RefCell<StableBTreeMap<UserID, GiftcardRefuelIDVec, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(USER_TO_GIFTCARDS_REFUEL_MEMORY_ID))
+            )
+        );
+        
+        pub(crate) static GIFTCARD_REFUEL_BY_ID: RefCell<StableBTreeMap<GiftcardRefuelID, GiftcardRefuel, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(GIFTCARD_REFUEL_BY_ID_MEMORY_ID))
+            )
+        );
     }
 
     

--- a/src/canisters-factory-backend/src/core/state/giftcards_refuel/types.rs
+++ b/src/canisters-factory-backend/src/core/state/giftcards_refuel/types.rs
@@ -1,13 +1,14 @@
 
 // src/core/state/drives/types.rs
-use std::fmt;
+use std::{borrow::Cow, fmt};
+use ic_stable_structures::{storable::Bound, Storable};
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
 use crate::core::{ state::giftcards_spawnorg::types::{DriveID, DriveRESTUrlEndpoint}, types::{ICPPrincipalString, PublicKeyICP, UserID}};
 
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, Ord, PartialOrd)]
 pub struct GiftcardRefuelID(pub String);
 impl fmt::Display for GiftcardRefuelID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -15,9 +16,28 @@ impl fmt::Display for GiftcardRefuelID {
     }
 }
 
+impl Storable for GiftcardRefuelID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256,
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize GiftcardRefuelID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize GiftcardRefuelID")
+    }
+}
+
 
 // Define a struct to track deployment history
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, Ord, PartialOrd, PartialEq, Eq, Hash)]
 pub struct FactoryRefuelHistoryRecord {
     pub note: String,
     pub giftcard_id: GiftcardRefuelID,
@@ -26,8 +46,28 @@ pub struct FactoryRefuelHistoryRecord {
     pub icp_principal: ICPPrincipalString,
 }
 
+impl Storable for FactoryRefuelHistoryRecord {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize FactoryRefuelHistoryRecord");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize FactoryRefuelHistoryRecord")
+    }
+}
+
+
 // Define a struct to track deployment history
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, Ord, PartialOrd, PartialEq, Eq, Hash)]
 pub struct GiftcardRefuel {
     pub id: GiftcardRefuelID,
     pub usd_revenue_cents: u64,
@@ -36,4 +76,72 @@ pub struct GiftcardRefuel {
     pub timestamp_ms: u64,
     pub external_id: String, // eg. stripe charge id or evm tx hash
     pub redeemed: bool,
+}
+
+impl Storable for GiftcardRefuel {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize GiftcardRefuel");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize GiftcardRefuel")
+    }
+}
+
+
+
+// Similar to StringVec in your reference code, but for GiftcardRefuelID
+#[derive(Clone, Debug, Deserialize, Serialize, SerdeDiff, Ord, PartialOrd, PartialEq, Eq)]
+pub struct GiftcardRefuelIDVec {
+    pub items: Vec<GiftcardRefuelID>,
+}
+
+impl GiftcardRefuelIDVec {
+    pub fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+    
+    pub fn with_item(item: GiftcardRefuelID) -> Self {
+        Self { items: vec![item] }
+    }
+    
+    pub fn push(&mut self, item: GiftcardRefuelID) {
+        self.items.push(item);
+    }
+    
+    pub fn contains(&self, item: &GiftcardRefuelID) -> bool {
+        self.items.contains(item)
+    }
+    
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+impl Storable for GiftcardRefuelIDVec {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 10240, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize GiftcardRefuelIDVec");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize GiftcardRefuelIDVec")
+    }
 }

--- a/src/canisters-factory-backend/src/core/state/giftcards_spawnorg/state.rs
+++ b/src/canisters-factory-backend/src/core/state/giftcards_spawnorg/state.rs
@@ -4,6 +4,11 @@ pub mod state {
     use std::cell::Cell;
     use std::cell::RefCell;
     use std::collections::HashMap;
+    use ic_stable_structures::memory_manager::MemoryId;
+    use ic_stable_structures::{StableBTreeMap,StableVec};
+    use ic_stable_structures::StableCell;
+    use ic_stable_structures::DefaultMemoryImpl;
+
     use crate::core::api::helpers::get_appropriate_url_endpoint;
     use crate::core::state::giftcards_spawnorg::types::DriveID;
     use crate::core::state::giftcards_spawnorg::types::DriveRESTUrlEndpoint;
@@ -11,22 +16,84 @@ pub mod state {
     use crate::core::state::giftcards_spawnorg::types::GiftcardSpawnOrgID;
     use crate::core::state::giftcards_spawnorg::types::GiftcardSpawnOrg;
 
+    use crate::core::state::giftcards_spawnorg::types::GiftcardSpawnOrgIDVec;
     use crate::core::types::{UserID,PublicKeyICP};
     use crate::debug_log;
+    use crate::MEMORY_MANAGER;
+
+
+    type Memory = ic_stable_structures::memory_manager::VirtualMemory<DefaultMemoryImpl>;
+    
+    // Define memory IDs for each storage
+    pub const VERSION_MEMORY_ID: MemoryId = MemoryId::new(10);
+    pub const OWNER_ID_MEMORY_ID: MemoryId = MemoryId::new(11);
+    pub const URL_ENDPOINT_MEMORY_ID: MemoryId = MemoryId::new(12);
+    pub const DEPLOYMENTS_BY_GIFTCARD_SPAWNORG_ID_MEMORY_ID: MemoryId = MemoryId::new(13);
+    pub const HISTORICAL_GIFTCARDS_SPAWNORGS_MEMORY_ID: MemoryId = MemoryId::new(14);
+    pub const DRIVE_TO_GIFTCARD_SPAWNORG_MEMORY_ID: MemoryId = MemoryId::new(15);
+    pub const USER_TO_GIFTCARDS_SPAWNORG_MEMORY_ID: MemoryId = MemoryId::new(16);
+    pub const GIFTCARD_SPAWNORG_BY_ID_MEMORY_ID: MemoryId = MemoryId::new(17);
 
     thread_local! { 
         // self info - immutable
         pub(crate) static CANISTER_ID: PublicKeyICP = PublicKeyICP(ic_cdk::api::id().to_text());
-        pub(crate) static VERSION: RefCell<String> = RefCell::new("OfficeX.Beta.0.0.1".to_string());
-        pub(crate) static OWNER_ID: RefCell<UserID> = RefCell::new(UserID("Anonymous_Owner".to_string()));
-        pub(crate) static URL_ENDPOINT: RefCell<DriveRESTUrlEndpoint> = RefCell::new(DriveRESTUrlEndpoint(format!("https://{}.icp0.io", CANISTER_ID.with(|id| id.0.clone()))));
         
-        // GiftcardSpawnOrg and deployment tracking
-        pub(crate) static DEPLOYMENTS_BY_GIFTCARD_SPAWNORG_ID: RefCell<HashMap<GiftcardSpawnOrgID, FactorySpawnHistoryRecord>> = RefCell::new(HashMap::new());
-        pub(crate) static HISTORICAL_GIFTCARDS_SPAWNORGS: RefCell<Vec<GiftcardSpawnOrgID>> = RefCell::new(Vec::new());
-        pub(crate) static DRIVE_TO_GIFTCARD_SPAWNORG_HASHTABLE: RefCell<HashMap<DriveID, GiftcardSpawnOrgID>> = RefCell::new(HashMap::new());
-        pub(crate) static USER_TO_GIFTCARDS_SPAWNORG_HASHTABLE: RefCell<HashMap<UserID, Vec<GiftcardSpawnOrgID>>> = RefCell::new(HashMap::new());
-        pub(crate) static GIFTCARD_SPAWNORG_BY_ID: RefCell<HashMap<GiftcardSpawnOrgID, GiftcardSpawnOrg>> = RefCell::new(HashMap::new());
+        // Convert regular variable to StableCell
+        pub(crate) static VERSION: RefCell<StableCell<String, Memory>> = RefCell::new(
+            StableCell::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(VERSION_MEMORY_ID)),
+                "OfficeX.Beta.0.0.2".to_string()
+            ).expect("Failed to initialize VERSION")
+        );
+        
+        pub(crate) static OWNER_ID: RefCell<StableCell<UserID, Memory>> = RefCell::new(
+            StableCell::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(OWNER_ID_MEMORY_ID)),
+                UserID("Anonymous_Owner".to_string())
+            ).expect("Failed to initialize OWNER_ID")
+        );
+        
+        pub(crate) static URL_ENDPOINT: RefCell<StableCell<DriveRESTUrlEndpoint, Memory>> = RefCell::new(
+            StableCell::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(URL_ENDPOINT_MEMORY_ID)),
+                DriveRESTUrlEndpoint(format!("https://{}.icp0.io", CANISTER_ID.with(|id| id.0.clone())))
+            ).expect("Failed to initialize URL_ENDPOINT")
+        );
+        
+        // Convert HashMap to StableBTreeMap for deployments
+        pub(crate) static DEPLOYMENTS_BY_GIFTCARD_SPAWNORG_ID: RefCell<StableBTreeMap<GiftcardSpawnOrgID, FactorySpawnHistoryRecord, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(DEPLOYMENTS_BY_GIFTCARD_SPAWNORG_ID_MEMORY_ID))
+            )
+        );
+        
+        // Convert Vec to StableVec for historical records
+        pub(crate) static HISTORICAL_GIFTCARDS_SPAWNORGS: RefCell<StableVec<GiftcardSpawnOrgID, Memory>> = RefCell::new(
+            StableVec::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(HISTORICAL_GIFTCARDS_SPAWNORGS_MEMORY_ID))
+            ).expect("Failed to initialize HISTORICAL_GIFTCARDS_SPAWNORGS")
+        );
+        
+        // Convert HashMap to StableBTreeMap for drive mappings
+        pub(crate) static DRIVE_TO_GIFTCARD_SPAWNORG_HASHTABLE: RefCell<StableBTreeMap<DriveID, GiftcardSpawnOrgID, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(DRIVE_TO_GIFTCARD_SPAWNORG_MEMORY_ID))
+            )
+        );
+        
+        // For HashMap<UserID, Vec<GiftcardSpawnOrgID>>, use a custom type (GiftcardSpawnOrgIDVec)
+        pub(crate) static USER_TO_GIFTCARDS_SPAWNORG_HASHTABLE: RefCell<StableBTreeMap<UserID, GiftcardSpawnOrgIDVec, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(USER_TO_GIFTCARDS_SPAWNORG_MEMORY_ID))
+            )
+        );
+        
+        // Convert HashMap to StableBTreeMap for giftcard storage
+        pub(crate) static GIFTCARD_SPAWNORG_BY_ID: RefCell<StableBTreeMap<GiftcardSpawnOrgID, GiftcardSpawnOrg, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(GIFTCARD_SPAWNORG_BY_ID_MEMORY_ID))
+            )
+        );
     }
 
     pub fn init_self_factory(
@@ -34,18 +101,19 @@ pub mod state {
     ) {
         debug_log!("Setting owner_id: {}", owner_id.0);
         OWNER_ID.with(|id| {
-            *id.borrow_mut() = owner_id.clone();
-            debug_log!("Confirmed owner_id set to: {}", id.borrow().0);
+            // Use set() instead of direct assignment
+            id.borrow_mut().set(owner_id.clone());
+            debug_log!("Confirmed owner_id set to: {}", id.borrow().get().0);
         });
-
+    
         // Handle the URL endpoint
         let endpoint = get_appropriate_url_endpoint();
         debug_log!("Setting URL endpoint to: {}", endpoint);
         URL_ENDPOINT.with(|url| {
-            *url.borrow_mut() = DriveRESTUrlEndpoint(endpoint);
-            debug_log!("Confirmed URL endpoint set to: {}", url.borrow().0);
+            // Use set() instead of direct assignment
+            url.borrow_mut().set(DriveRESTUrlEndpoint(endpoint));
+            debug_log!("Confirmed URL endpoint set to: {}", url.borrow().get().0);
         });
-        
     }
     
 }

--- a/src/canisters-factory-backend/src/core/state/giftcards_spawnorg/types.rs
+++ b/src/canisters-factory-backend/src/core/state/giftcards_spawnorg/types.rs
@@ -1,12 +1,13 @@
 
 // src/core/state/drives/types.rs
-use std::fmt;
+use std::{borrow::Cow, fmt};
+use ic_stable_structures::{storable::Bound, Storable};
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
 use crate::core::{ types::{ICPPrincipalString, PublicKeyICP, UserID}};
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, PartialOrd, Ord)]
 pub struct DriveID(pub String);
 impl fmt::Display for DriveID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -14,12 +15,51 @@ impl fmt::Display for DriveID {
     }
 }
 
+impl Storable for DriveID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256 * 4,
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize DriveID");
+        Cow::Owned(bytes)
+    }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize DriveID")
+    }
+}
+
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, PartialOrd, Ord)]
 pub struct GiftcardSpawnOrgID(pub String);
 impl fmt::Display for GiftcardSpawnOrgID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+
+impl Storable for GiftcardSpawnOrgID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256,
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize GiftcardSpawnOrgID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize GiftcardSpawnOrgID")
     }
 }
 
@@ -37,6 +77,25 @@ pub struct FactorySpawnHistoryRecord {
     pub timestamp_ms: u64,
 }
 
+impl Storable for FactorySpawnHistoryRecord {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 1024, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize FactorySpawnHistoryRecord");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize FactorySpawnHistoryRecord")
+    }
+}
+
 // Define a struct to track deployment history
 #[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
 pub struct GiftcardSpawnOrg {
@@ -51,10 +110,99 @@ pub struct GiftcardSpawnOrg {
 }
 
 
+impl Storable for GiftcardSpawnOrg {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 2048, // Adjust based on your needs, increased for disk_auth_json
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize GiftcardSpawnOrg");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize GiftcardSpawnOrg")
+    }
+}
+
+
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
 pub struct DriveRESTUrlEndpoint(pub String);
 impl fmt::Display for DriveRESTUrlEndpoint {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+
+impl Storable for DriveRESTUrlEndpoint {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256,
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize DriveRESTUrlEndpoint");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize DriveRESTUrlEndpoint")
+    }
+}
+
+
+// Similar to StringVec in your reference code, but for GiftcardSpawnOrgID
+#[derive(Clone, Debug, Deserialize, Serialize, SerdeDiff)]
+pub struct GiftcardSpawnOrgIDVec {
+    pub items: Vec<GiftcardSpawnOrgID>,
+}
+
+impl GiftcardSpawnOrgIDVec {
+    pub fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+    
+    pub fn with_item(item: GiftcardSpawnOrgID) -> Self {
+        Self { items: vec![item] }
+    }
+    
+    pub fn push(&mut self, item: GiftcardSpawnOrgID) {
+        self.items.push(item);
+    }
+    
+    pub fn contains(&self, item: &GiftcardSpawnOrgID) -> bool {
+        self.items.contains(item)
+    }
+    
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+impl Storable for GiftcardSpawnOrgIDVec {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 10240, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize GiftcardSpawnOrgIDVec");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize GiftcardSpawnOrgIDVec")
     }
 }

--- a/src/canisters-factory-backend/src/rest/auth.rs
+++ b/src/canisters-factory-backend/src/rest/auth.rs
@@ -158,7 +158,7 @@ pub fn authenticate_request(req: &HttpRequest) -> Option<ApiKey> {
             
             // Look up the API key ID using the value
             let api_key_id = APIKEYS_BY_VALUE_HASHTABLE.with(|store| {
-                store.borrow().get(&api_key_value).cloned()
+                store.borrow().get(&api_key_value).clone()
             });
             
             if let Some(api_key_id) = api_key_id {
@@ -166,7 +166,7 @@ pub fn authenticate_request(req: &HttpRequest) -> Option<ApiKey> {
                 
                 // Look up the full API key using the ID
                 let full_api_key = APIKEYS_BY_ID_HASHTABLE.with(|store| {
-                    store.borrow().get(&api_key_id).cloned()
+                    store.borrow().get(&api_key_id).clone()
                 });
                 
                 // Check if key exists and validate expiration/revocation

--- a/src/canisters-official-backend/src/core/api/actions.rs
+++ b/src/canisters-official-backend/src/core/api/actions.rs
@@ -55,7 +55,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                         PermissionGranteeID::User(user_id.clone())
                     ).await;
 
-                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
         
                     // User needs at least View permission to get file details
                     if !is_owner && !user_permissions.contains(&DirectoryPermissionType::View) {
@@ -112,7 +112,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                         resource_name: file.name.clone(),
                         drive_id: DRIVE_ID.with(|id| id.clone()),
                         timestamp_ms: ic_cdk::api::time() / 1_000_000,
-                        endpoint_url: URL_ENDPOINT.with(|url| url.borrow().clone()),
+                        endpoint_url: URL_ENDPOINT.with(|url| url.borrow().get().clone()),
                         metadata: None
                     };
                     fire_directory_webhook(
@@ -183,7 +183,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                         PermissionGranteeID::User(user_id.clone())
                     ).await;
 
-                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
         
                     if !is_owner && !user_permissions.contains(&DirectoryPermissionType::View) {
                         return Err(DirectoryActionErrorInfo {
@@ -240,7 +240,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                         resource_name: folder.name.clone(),
                         drive_id: DRIVE_ID.with(|id| id.clone()),
                         timestamp_ms: ic_cdk::api::time() / 1_000_000,
-                        endpoint_url: URL_ENDPOINT.with(|url| url.borrow().clone()),
+                        endpoint_url: URL_ENDPOINT.with(|url| url.borrow().get().clone()),
                         metadata: None
                     };
                     fire_directory_webhook(
@@ -303,7 +303,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                         PermissionGranteeID::User(user_id.clone())
                     ).await;
 
-                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
         
                     if !is_owner && !user_permissions.contains(&DirectoryPermissionType::Upload) && 
                        !user_permissions.contains(&DirectoryPermissionType::Edit) &&
@@ -394,7 +394,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                         });
                     }
 
-                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
 
                     // Get parent folder ID where the new folder will be created
                     let parent_folder_id = payload.parent_folder_uuid;
@@ -542,7 +542,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                     let has_edit_permission = user_permissions.contains(&DirectoryPermissionType::Edit) ||
                                             user_permissions.contains(&DirectoryPermissionType::Manage);
 
-                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
 
                     if !is_owner && !is_creator_with_upload && !has_edit_permission {
                         return Err(DirectoryActionErrorInfo {
@@ -692,7 +692,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                     let has_edit_permission = user_permissions.contains(&DirectoryPermissionType::Edit) ||
                                             user_permissions.contains(&DirectoryPermissionType::Manage);
 
-                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
 
                     if !is_owner && !is_creator_with_upload && !has_edit_permission {
                         return Err(DirectoryActionErrorInfo {
@@ -830,7 +830,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                     let has_delete_permission = user_permissions.contains(&DirectoryPermissionType::Delete) ||
                                               user_permissions.contains(&DirectoryPermissionType::Manage);
         
-                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
 
                     if !is_owner && !is_creator_with_upload && !has_delete_permission {
                         return Err(DirectoryActionErrorInfo {
@@ -932,7 +932,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
         
                     let has_delete_permission = user_permissions.contains(&DirectoryPermissionType::Delete) ||
                                               user_permissions.contains(&DirectoryPermissionType::Manage);
-                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
 
                     if !is_owner && !is_creator_with_upload && !has_delete_permission {
                         return Err(DirectoryActionErrorInfo {
@@ -1021,7 +1021,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                         source_resource_id,
                         PermissionGranteeID::User(user_id.clone())
                     ).await;
-                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
         
                     if !user_permissions.contains(&DirectoryPermissionType::View) && !is_owner {
                         return Err(DirectoryActionErrorInfo {
@@ -1136,7 +1136,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                         source_resource_id,
                         PermissionGranteeID::User(user_id.clone())
                     ).await;
-                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
         
                     if !user_permissions.contains(&DirectoryPermissionType::View) && !is_owner {
                         return Err(DirectoryActionErrorInfo {
@@ -1262,7 +1262,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
         
                     let has_move_permission = source_permissions.contains(&DirectoryPermissionType::Edit) ||
                                             source_permissions.contains(&DirectoryPermissionType::Manage);
-                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
 
                     if !is_owner && !is_creator_with_upload && !has_move_permission {
                         return Err(DirectoryActionErrorInfo {
@@ -1350,7 +1350,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                             message: format!("Validation error: {}", validation_error.message),
                         });
                     }
-                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
 
                     // Get the folder ID from either resource_id or resource_path
                     let folder_id = payload.id;
@@ -1425,7 +1425,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                         PermissionGranteeID::User(user_id.clone())
                     ).await;
 
-                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
         
                     if !is_owner && !dest_permissions.contains(&DirectoryPermissionType::Upload) && 
                        !dest_permissions.contains(&DirectoryPermissionType::Edit) &&
@@ -1527,7 +1527,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                         let has_restore_permission = folder_permissions.contains(&DirectoryPermissionType::Edit) ||
                                                   folder_permissions.contains(&DirectoryPermissionType::Manage);
         
-                        let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                        let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
 
                         if !is_owner && !is_creator_with_upload && !has_restore_permission {
                             return Err(DirectoryActionErrorInfo {
@@ -1607,7 +1607,7 @@ pub async fn pipe_action(action: DirectoryAction, user_id: UserID) -> Result<Dir
                                 file_permissions.contains(&DirectoryPermissionType::Upload);
                             let has_restore_permission = file_permissions.contains(&DirectoryPermissionType::Edit) ||
                                                     file_permissions.contains(&DirectoryPermissionType::Manage);
-                            let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+                            let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow().get());
 
                             if !is_owner && !is_creator_with_upload && !has_restore_permission {
                                 return Err(DirectoryActionErrorInfo {

--- a/src/canisters-official-backend/src/core/api/drive.rs
+++ b/src/canisters-official-backend/src/core/api/drive.rs
@@ -336,8 +336,9 @@ pub mod drive {
                 Some(FileConflictResolutionEnum::REPLACE) | Some(FileConflictResolutionEnum::KEEP_NEWER) => {
                     // Update the prior version's next_version pointer
                     file_uuid_to_metadata.with_mut(|map| {
-                        if let Some(existing_file) = map.get_mut(&existing_uuid) {
+                        if let Some(mut existing_file) = map.get(&existing_uuid) {
                             existing_file.next_version = Some(new_file_uuid.clone());
+                            map.insert(existing_uuid.clone(), existing_file);
                         }
                     });
                     
@@ -550,10 +551,11 @@ pub mod drive {
     
         // Update the metadata with the correct expires_at value
         folder_uuid_to_metadata.with_mut(|map| {
-            if let Some(folder) = map.get_mut(&new_folder_uuid) {
+            if let Some(mut folder) = map.get(&new_folder_uuid) {
                 folder.expires_at = expires_at;
+                map.insert(new_folder_uuid.clone(), folder);
             }
-        });        
+        });
     
         // Get and return the updated folder metadata
         folder_uuid_to_metadata
@@ -620,10 +622,11 @@ pub mod drive {
     
         // Update folder metadata using with_mut
         folder_uuid_to_metadata.with_mut(|map| {
-            if let Some(folder) = map.get_mut(&folder_id) {
+            if let Some(mut folder) = map.get(&folder_id) {
                 folder.name = new_name;
                 folder.full_directory_path = DriveFullFilePath(new_folder_path.clone());
                 folder.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                map.insert(folder_id.clone(), folder);
             }
         });
     
@@ -642,11 +645,12 @@ pub mod drive {
             let parent_full_path = format!("{}::/{}/", storage_part, parent_path);
             if let Some(parent_uuid) = full_folder_path_to_uuid.get(&DriveFullFilePath(parent_full_path.clone())) {
                 folder_uuid_to_metadata.with_mut(|map| {
-                    if let Some(parent_folder) = map.get_mut(&parent_uuid) {
+                    if let Some(mut parent_folder) = map.get(&parent_uuid) {
                         if !parent_folder.subfolder_uuids.contains(&folder_id) {
                             parent_folder.subfolder_uuids.push(folder_id.clone());
                             ic_cdk::println!("Added folder UUID to parent folder's subfolder_uuids");
                         }
+                        map.insert(parent_uuid.clone(), parent_folder);
                     }
                 });
             } else {
@@ -704,7 +708,7 @@ pub mod drive {
     
         // Update file metadata
         file_uuid_to_metadata.with_mut(|map| {
-            if let Some(file) = map.get_mut(&file_id) {
+            if let Some(mut file) = map.get(&file_id) {
                 file.name = new_name.clone();
                 file.full_directory_path = DriveFullFilePath(new_path.clone());
                 file.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
@@ -713,7 +717,7 @@ pub mod drive {
                     .next()
                     .unwrap_or("")
                     .to_string();
-                ic_cdk::println!("Updated file metadata: {:?}", file);
+                map.insert(file_id.clone(), file);
             }
         });
     
@@ -795,8 +799,9 @@ pub mod drive {
             // Remove from parent's subfolder list
             if let Some(parent_id) = folder.parent_folder_uuid {
                 folder_uuid_to_metadata.with_mut(|map| {
-                    if let Some(parent) = map.get_mut(&parent_id) {
+                    if let Some(mut parent) = map.get(&parent_id) {
                         parent.subfolder_uuids.retain(|id| id != folder_id);
+                        map.insert(parent_id, parent);
                     }
                 });
             }
@@ -819,7 +824,7 @@ pub mod drive {
                 let mut file_ids = Vec::new();
                 
                 folder_uuid_to_metadata.with_mut(|map| {
-                    if let Some(current_folder) = map.get_mut(&current_folder_id) {
+                    if let Some(mut current_folder) = map.get(&current_folder_id) {
                         if current_folder_id == *folder_id {
                             // Main folder gets the original parent path
                             current_folder.restore_trash_prior_folder_uuid = Some(folder.parent_folder_uuid.clone().unwrap());
@@ -827,19 +832,22 @@ pub mod drive {
                             // Subfolders keep their current path
                             current_folder.restore_trash_prior_folder_uuid = Some(current_folder.parent_folder_uuid.clone().unwrap());
                         }
-    
+                
                         // Add subfolders to stack
                         stack.extend(current_folder.subfolder_uuids.clone());
                         // Get the file IDs for processing after we release this borrow
                         file_ids = current_folder.file_uuids.clone();
+                        
+                        map.insert(current_folder_id.clone(), current_folder);
                     }
                 });
     
                 // Now set restore info for all files using file_uuid_to_metadata
                 for file_id in file_ids {
                     file_uuid_to_metadata.with_mut(|file_map| {
-                        if let Some(file) = file_map.get_mut(&file_id) {
+                        if let Some(mut file) = file_map.get(&file_id) {
                             file.restore_trash_prior_folder_uuid = Some(current_folder_id.clone());
+                            file_map.insert(file_id, file);
                         }
                     });
                 }
@@ -910,16 +918,18 @@ pub mod drive {
             // Handle version chain
             if let Some(prior_id) = &file.prior_version {
                 file_uuid_to_metadata.with_mut(|map| {
-                    if let Some(prior_file) = map.get_mut(prior_id) {
+                    if let Some(mut prior_file) = map.get(prior_id) {
                         prior_file.next_version = file.next_version.clone();
+                        map.insert(prior_id.clone(), prior_file);
                     }
                 });
             }
     
             if let Some(next_id) = &file.next_version {
                 file_uuid_to_metadata.with_mut(|map| {
-                    if let Some(next_file) = map.get_mut(next_id) {
+                    if let Some(mut next_file) = map.get(next_id) {
                         next_file.prior_version = file.prior_version.clone();
+                        map.insert(next_id.clone(), next_file);
                     }
                 });
             }
@@ -930,8 +940,9 @@ pub mod drive {
     
             // Remove from parent folder's file list
             folder_uuid_to_metadata.with_mut(|map| {
-                if let Some(folder) = map.get_mut(&folder_uuid) {
+                if let Some(mut folder) = map.get(&folder_uuid) {
                     folder.file_uuids.retain(|id| id != file_id);
+                    map.insert(folder_uuid.clone(), folder);
                 }
             });
 
@@ -954,8 +965,9 @@ pub mod drive {
     
             // Set restore_trash_prior_folder_uuid BEFORE moving the file
             file_uuid_to_metadata.with_mut(|map| {
-                if let Some(file) = map.get_mut(file_id) {
+                if let Some(mut file) = map.get(file_id) {
                     file.restore_trash_prior_folder_uuid = Some(file.parent_folder_uuid.clone());
+                    map.insert(file_id.clone(), file);
                 }
             });
     
@@ -1065,9 +1077,10 @@ pub mod drive {
 
         // Update destination folder's file list
         folder_uuid_to_metadata.with_mut(|map| {
-            if let Some(folder) = map.get_mut(&destination_folder.id) {
+            if let Some(mut folder) = map.get(&destination_folder.id) {
                 folder.file_uuids.push(new_file_uuid.clone());
                 folder.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                map.insert(destination_folder.id.clone(), folder);
             }
         });
 
@@ -1121,9 +1134,10 @@ pub mod drive {
     
         // Update destination folder's subfolder list
         folder_uuid_to_metadata.with_mut(|map| {
-            if let Some(folder) = map.get_mut(&destination_folder.id) {
+            if let Some(mut folder) = map.get(&destination_folder.id) {
                 folder.subfolder_uuids.push(new_folder_uuid.clone());
                 folder.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                map.insert(destination_folder.id.clone(), folder);
             }
         });
     
@@ -1131,8 +1145,9 @@ pub mod drive {
         for subfolder_id in &source_folder.subfolder_uuids {
             if let Ok(copied_subfolder) = copy_folder(subfolder_id, &new_folder_metadata, file_conflict_resolution.clone(), None) {
                 folder_uuid_to_metadata.with_mut(|map| {
-                    if let Some(folder) = map.get_mut(&new_folder_uuid) {
+                    if let Some(mut folder) = map.get(&new_folder_uuid) {
                         folder.subfolder_uuids.push(copied_subfolder.id.clone());
+                        map.insert(new_folder_uuid.clone(), folder);
                     }
                 });
             }
@@ -1142,8 +1157,9 @@ pub mod drive {
         for file_id in &source_folder.file_uuids {
             if let Ok(copied_file) = copy_file(file_id, &new_folder_metadata, file_conflict_resolution.clone(), None) {
                 folder_uuid_to_metadata.with_mut(|map| {
-                    if let Some(folder) = map.get_mut(&new_folder_uuid) {
+                    if let Some(mut folder) = map.get(&new_folder_uuid) {
                         folder.file_uuids.push(copied_file.id.clone());
+                        map.insert(new_folder_uuid.clone(), folder);
                     }
                 });
             }
@@ -1188,11 +1204,12 @@ pub mod drive {
     
         // Update file metadata
         file_uuid_to_metadata.with_mut(|map| {
-            if let Some(file) = map.get_mut(file_id) {
+            if let Some(mut file) = map.get(file_id) {
                 file.name = final_name;
                 file.parent_folder_uuid = destination_folder.id.clone();
                 file.full_directory_path = DriveFullFilePath(final_path.clone());
                 file.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                map.insert(file_id.clone(), file);
             }
         });
     
@@ -1201,17 +1218,19 @@ pub mod drive {
     
         // Remove file from source folder
         folder_uuid_to_metadata.with_mut(|map| {
-            if let Some(folder) = map.get_mut(&source_folder_id) {
+            if let Some(mut folder) = map.get(&source_folder_id) {
                 folder.file_uuids.retain(|id| id != file_id);
                 folder.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                map.insert(source_folder_id.clone(), folder);
             }
         });
     
         // Add file to destination folder
         folder_uuid_to_metadata.with_mut(|map| {
-            if let Some(folder) = map.get_mut(&destination_folder.id) {
+            if let Some(mut folder) = map.get(&destination_folder.id) {
                 folder.file_uuids.push(file_id.clone());
                 folder.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                map.insert(destination_folder.id.clone(), folder);
             }
         });
     
@@ -1261,11 +1280,12 @@ pub mod drive {
         
         // Update folder metadata using with_mut.
         folder_uuid_to_metadata.with_mut(|map| {
-            if let Some(folder) = map.get_mut(folder_id) {
+            if let Some(mut folder) = map.get(folder_id) {
                 folder.name = final_name.clone();
                 folder.parent_folder_uuid = Some(destination_folder.id.clone());
                 folder.full_directory_path = DriveFullFilePath(final_path.clone());
                 folder.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                map.insert(folder_id.clone(), folder);
             }
         });
     
@@ -1281,18 +1301,20 @@ pub mod drive {
         // Remove folder from old parent's subfolder list.
         if let Some(old_parent_id) = &source_folder.parent_folder_uuid {
             folder_uuid_to_metadata.with_mut(|map| {
-                if let Some(parent) = map.get_mut(old_parent_id) {
+                if let Some(mut parent) = map.get(old_parent_id) {
                     parent.subfolder_uuids.retain(|id| id != folder_id);
                     parent.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                    map.insert(old_parent_id.clone(), parent);
                 }
             });
         }
     
         // Add folder to new parent's subfolder list.
         folder_uuid_to_metadata.with_mut(|map| {
-            if let Some(new_parent) = map.get_mut(&destination_folder.id) {
+            if let Some(mut new_parent) = map.get(&destination_folder.id) {
                 new_parent.subfolder_uuids.push(folder_id.clone());
                 new_parent.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                map.insert(destination_folder.id.clone(), new_parent);
             }
         });
     
@@ -1387,19 +1409,21 @@ pub mod drive {
                     // Process subfolders
                     for subfolder_id in &current_folder.subfolder_uuids {
                         folder_uuid_to_metadata.with_mut(|map| {
-                            if let Some(subfolder) = map.get_mut(subfolder_id) {
+                            if let Some(mut subfolder) = map.get(subfolder_id) {
                                 subfolder.restore_trash_prior_folder_uuid = None;
+                                map.insert(subfolder_id.clone(), subfolder);
                             }
                         });
                         restored_folders.push(subfolder_id.clone());
                         stack.push(subfolder_id.clone());
                     }
-
+            
                     // Process files
                     for file_id in &current_folder.file_uuids {
                         file_uuid_to_metadata.with_mut(|map| {
-                            if let Some(file) = map.get_mut(file_id) {
+                            if let Some(mut file) = map.get(file_id) {
                                 file.restore_trash_prior_folder_uuid = None;
+                                map.insert(file_id.clone(), file);
                             }
                         });
                         restored_files.push(file_id.clone());
@@ -1409,8 +1433,9 @@ pub mod drive {
 
             // Clear restore_trash_prior_folder_uuid for the main folder
             folder_uuid_to_metadata.with_mut(|map| {
-                if let Some(folder) = map.get_mut(&folder_id) {
+                if let Some(mut folder) = map.get(&folder_id) {
                     folder.restore_trash_prior_folder_uuid = None;
+                    map.insert(folder_id.clone(), folder);
                 }
             });
 
@@ -1488,8 +1513,9 @@ pub mod drive {
 
             // Clear restore_trash_prior_folder_uuid
             file_uuid_to_metadata.with_mut(|map| {
-                if let Some(file) = map.get_mut(&file_id) {
+                if let Some(mut file) = map.get(&file_id) {
                     file.restore_trash_prior_folder_uuid = None;
+                    map.insert(file_id.clone(), file);
                 }
             });
 

--- a/src/canisters-official-backend/src/core/api/drive.rs
+++ b/src/canisters-official-backend/src/core/api/drive.rs
@@ -172,7 +172,7 @@ pub mod drive {
         let disk = DISKS_BY_ID_HASHTABLE.with(|map| {
             map.borrow()
                 .get(&disk_id)
-                .cloned()
+                .map(|d| d.clone())
         }).ok_or_else(|| "Disk not found".to_string())?;
 
 
@@ -233,7 +233,7 @@ pub mod drive {
                                 let disk = DISKS_BY_ID_HASHTABLE.with(|map| {
                                     map.borrow()
                                         .get(&disk_id)
-                                        .cloned()
+                                        .map(|d| d.clone())
                                 }).ok_or_else(|| "Disk not found".to_string())?;
     
                                 // Example using an "existing file" upload.
@@ -361,7 +361,7 @@ pub mod drive {
         let disk = DISKS_BY_ID_HASHTABLE.with(|map| {
             map.borrow()
                 .get(&disk_id)
-                .cloned()
+                .map(|d| d.clone())
         }).ok_or_else(|| "Disk not found".to_string())?;
     
     
@@ -472,7 +472,7 @@ pub mod drive {
         let disk = DISKS_BY_ID_HASHTABLE.with(|map| {
             map.borrow()
                 .get(&disk_id)
-                .cloned()
+                .map(|d| d.clone())
         }).ok_or_else(|| "Disk not found".to_string())?;
         
         debug_log!("sanitized_path: {}", sanitized_path);
@@ -1025,7 +1025,7 @@ pub mod drive {
             let disk = DISKS_BY_ID_HASHTABLE.with(|map| {
                 map.borrow()
                     .get(&source_file.disk_id)
-                    .cloned()
+                    .map(|d| d.clone())
             }).ok_or_else(|| "Disk not found".to_string())?;
 
             let aws_auth: AwsBucketAuth = serde_json::from_str(&disk.auth_json
@@ -1354,7 +1354,7 @@ pub mod drive {
                         let disk = DISKS_BY_ID_HASHTABLE.with(|map| {
                             map.borrow()
                                 .get(&disk_id)
-                                .cloned()
+                                .map(|d| d.clone())
                         }).ok_or_else(|| "Disk not found".to_string())?;
                         let root_folder = folder_uuid_to_metadata
                             .get(&disk.root_folder.clone())
@@ -1461,7 +1461,7 @@ pub mod drive {
                         let disk = DISKS_BY_ID_HASHTABLE.with(|map| {
                             map.borrow()
                                 .get(&disk_id)
-                                .cloned()
+                                .map(|d| d.clone())
                         }).ok_or_else(|| "Disk not found".to_string())?;
                         let root_folder = folder_uuid_to_metadata
                             .get(&disk.root_folder.clone())

--- a/src/canisters-official-backend/src/core/api/internals.rs
+++ b/src/canisters-official-backend/src/core/api/internals.rs
@@ -679,7 +679,7 @@ pub mod drive_internals {
             resource_id: "shared-with-me".to_string(),
             resource_name: "Shared with me".to_string(),
         });
-        let disk = DISKS_BY_ID_HASHTABLE.with(|map| map.borrow().get(&disk_id).cloned());
+        let disk = DISKS_BY_ID_HASHTABLE.with(|map| map.borrow().get(&disk_id).map(|d| d.clone()));
         if let Some(disk) = disk {
             breadcrumbs.push_front(FilePathBreadcrumb {
                 resource_id: disk.root_folder.clone().to_string(),

--- a/src/canisters-official-backend/src/core/api/internals.rs
+++ b/src/canisters-official-backend/src/core/api/internals.rs
@@ -94,11 +94,12 @@ pub mod drive_internals {
             folder_uuid_to_metadata.insert(FolderID(trash_folder_uuid.clone()), trash_folder);
             
             // Add trash folder to root's subfolders
-            folder_uuid_to_metadata.with_mut(|map| {
-                if let Some(root_folder) = map.get_mut(&root_uuid) {
-                    root_folder.subfolder_uuids.push(FolderID(trash_folder_uuid));
-                }
-            });
+folder_uuid_to_metadata.with_mut(|map| {
+    if let Some(mut root_folder) = map.get(&root_uuid) {
+        root_folder.subfolder_uuids.push(FolderID(trash_folder_uuid));
+        map.insert(root_uuid.clone(), root_folder);
+    }
+});
         }
 
         root_uuid
@@ -128,8 +129,9 @@ pub mod drive_internals {
             
             // Update folder metadata
             folder_uuid_to_metadata.with_mut(|map| {
-                if let Some(subfolder) = map.get_mut(subfolder_id) {
+                if let Some(mut subfolder) = map.get(subfolder_id) {
                     subfolder.full_directory_path = new_subfolder_path.clone();
+                    map.insert(subfolder_id.clone(), subfolder);
                 }
             });
             
@@ -154,8 +156,9 @@ pub mod drive_internals {
             
             // Update file metadata
             file_uuid_to_metadata.with_mut(|map| {
-                if let Some(file) = map.get_mut(file_id) {
+                if let Some(mut file) = map.get(file_id) {
                     file.full_directory_path = new_file_path.clone();
+                    map.insert(file_id.clone(), file);
                 }
             });
             
@@ -248,10 +251,11 @@ pub mod drive_internals {
 
                 // Update parent folder's subfolder_uuids
                 folder_uuid_to_metadata.with_mut(|map| {
-                    if let Some(parent_folder) = map.get_mut(&parent_uuid) {
+                    if let Some(mut parent_folder) = map.get(&parent_uuid) {
                         if !parent_folder.subfolder_uuids.contains(&new_folder_uuid) {
                             parent_folder.subfolder_uuids.push(new_folder_uuid.clone());
                         }
+                        map.insert(parent_uuid.clone(), parent_folder);
                     }
                 });
 
@@ -289,7 +293,7 @@ pub mod drive_internals {
 
     pub fn update_folder_file_uuids(folder_uuid: &FolderID, file_uuid: &FileID, is_add: bool) {
         folder_uuid_to_metadata.with_mut(|map| {
-            if let Some(folder) = map.get_mut(folder_uuid) {
+            if let Some(mut folder) = map.get(folder_uuid) {
                 if is_add {
                     if !folder.file_uuids.contains(file_uuid) {
                         folder.file_uuids.push(file_uuid.clone());
@@ -297,6 +301,7 @@ pub mod drive_internals {
                 } else {
                     folder.file_uuids.retain(|uuid| uuid != file_uuid);
                 }
+                map.insert(folder_uuid.clone(), folder);
             }
         });
     }

--- a/src/canisters-official-backend/src/core/api/permissions/directory.rs
+++ b/src/canisters-official-backend/src/core/api/permissions/directory.rs
@@ -350,7 +350,7 @@ pub async fn derive_directory_breadcrumbs(
                     // Add the parent folder only if user has permission
                     if let Some(folder_metadata) = folder_uuid_to_metadata.get(&file_metadata.parent_folder_uuid) {
                         if (folder_metadata.full_directory_path == DriveFullFilePath(format!("{}::/", folder_metadata.disk_id.to_string()))) {
-                            let disk = DISKS_BY_ID_HASHTABLE.with(|map| map.borrow().get(&folder_metadata.disk_id).cloned());
+                            let disk = DISKS_BY_ID_HASHTABLE.with(|map| map.borrow().get(&folder_metadata.disk_id).map(|d| d.clone()));
                             if let Some(disk) = disk {
                                 breadcrumbs.push_front(FilePathBreadcrumb {
                                     resource_id: folder_metadata.id.clone().to_string(),
@@ -402,7 +402,7 @@ pub async fn derive_directory_breadcrumbs(
             }
             
             if (folder_metadata.full_directory_path == DriveFullFilePath(format!("{}::/", folder_metadata.disk_id.to_string()))) {
-                let disk = DISKS_BY_ID_HASHTABLE.with(|map| map.borrow().get(&folder_metadata.disk_id).cloned());
+                let disk = DISKS_BY_ID_HASHTABLE.with(|map| map.borrow().get(&folder_metadata.disk_id).map(|d| d.clone()));
                 if let Some(disk) = disk {
                     breadcrumbs.push_front(FilePathBreadcrumb {
                         resource_id: folder_metadata.id.clone().to_string(),
@@ -444,7 +444,7 @@ pub async fn derive_directory_breadcrumbs(
             Some(folder_metadata) => {
 
                 if (folder_metadata.full_directory_path == DriveFullFilePath(format!("{}::/", folder_metadata.disk_id.to_string()))) {
-                    let disk = DISKS_BY_ID_HASHTABLE.with(|map| map.borrow().get(&folder_metadata.disk_id).cloned());
+                    let disk = DISKS_BY_ID_HASHTABLE.with(|map| map.borrow().get(&folder_metadata.disk_id).map(|d| d.clone()));
                     if let Some(disk) = disk {
                         breadcrumbs.push_front(FilePathBreadcrumb {
                             resource_id: folder_metadata.id.clone().to_string(),

--- a/src/canisters-official-backend/src/core/api/permissions/directory.rs
+++ b/src/canisters-official-backend/src/core/api/permissions/directory.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashSet, VecDeque};
 
-use crate::{core::{api::{internals::drive_internals::is_user_in_group, types::DirectoryIDError}, state::{directory::{state::state::{file_uuid_to_metadata, folder_uuid_to_metadata}, types::{DriveFullFilePath, FileID, FolderID}}, disks::state::state::DISKS_BY_ID_HASHTABLE, drives::state::state::OWNER_ID, groups::{state::state::is_user_on_group, types::GroupID}, permissions::{state::state::{DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE, DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE}, types::{DirectoryPermission, DirectoryPermissionType, PermissionGranteeID, PlaceholderPermissionGranteeID, PUBLIC_GRANTEE_ID}}}, types::UserID}, rest::directory::types::{DirectoryResourceID, DirectoryResourcePermissionFE, FilePathBreadcrumb}};
+use crate::{core::{api::{internals::drive_internals::is_user_in_group, types::DirectoryIDError}, state::{directory::{state::state::{file_uuid_to_metadata, folder_uuid_to_metadata}, types::{DriveFullFilePath, FileID, FolderID}}, disks::state::state::DISKS_BY_ID_HASHTABLE, drives::state::state::OWNER_ID, groups::{state::state::is_user_on_group, types::GroupID}, permissions::{state::{helpers::{get_directory_permission_by_id, get_directory_permission_ids_for_resource}, state::{DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE, DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE}}, types::{DirectoryPermission, DirectoryPermissionType, PermissionGranteeID, PlaceholderPermissionGranteeID, PUBLIC_GRANTEE_ID}}}, types::UserID}, rest::directory::types::{DirectoryResourceID, DirectoryResourcePermissionFE, FilePathBreadcrumb}};
 
 
 // Check if a user can CRUD the permission record
@@ -155,7 +155,7 @@ async fn check_directory_resource_permissions(
             DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE.with(|permissions_by_id| {
                 let permissions = permissions_by_id.borrow();
                 permission_ids.iter()
-                    .filter_map(|id| permissions.get(id).cloned())
+                    .filter_map(|id| permissions.get(id).clone())
                     .collect::<Vec<_>>()
             })
         } else {
@@ -263,47 +263,43 @@ pub fn parse_permission_grantee_id(id_str: &str) -> Result<PermissionGranteeID, 
 }
 
 // Add a helper function to get permissions for a resource
+// Add a helper function to get permissions for a resource
 pub fn preview_directory_permissions(
     resource_id: &DirectoryResourceID,
     user_id: &UserID,
 ) -> Vec<DirectoryResourcePermissionFE> {
-    
     // Get permission IDs for each permission type
     let mut resource_permissions = Vec::new();
     
-    DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|permissions_by_resource| {
-        if let Some(permission_ids) = permissions_by_resource.borrow().get(resource_id) {
-            DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE.with(|permissions_by_id| {
-                let permissions = permissions_by_id.borrow();
-                
-                for permission_id in permission_ids {
-                    if let Some(permission) = permissions.get(permission_id) {
-                        let permission_granted_to = match parse_permission_grantee_id(&permission.granted_to.to_string()) {
-                            Ok(parsed_grantee) => parsed_grantee,
-                            Err(_) => continue,
-                        };
+    // Get all permission IDs for this resource using helper function
+    if let Some(permission_ids) = get_directory_permission_ids_for_resource(resource_id) {
+        for permission_id in &permission_ids.permissions {
+            // Get the permission details using helper function
+            if let Some(permission) = get_directory_permission_by_id(permission_id) {
+                let permission_granted_to = match parse_permission_grantee_id(&permission.granted_to.to_string()) {
+                    Ok(parsed_grantee) => parsed_grantee,
+                    Err(_) => continue,
+                };
 
-                        // Check if permission applies to this user
-                        let applies = match &permission_granted_to {
-                            PermissionGranteeID::Public => true,
-                            PermissionGranteeID::User(permission_user_id) => permission_user_id == user_id,
-                            PermissionGranteeID::Group(group_id) => is_user_in_group(user_id, group_id),
-                            _ => false
-                        };
+                // Check if permission applies to this user
+                let applies = match &permission_granted_to {
+                    PermissionGranteeID::Public => true,
+                    PermissionGranteeID::User(permission_user_id) => permission_user_id == user_id,
+                    PermissionGranteeID::Group(group_id) => is_user_in_group(user_id, group_id),
+                    _ => false
+                };
 
-                        if applies {
-                            for grant_type in &permission.permission_types {
-                                resource_permissions.push(DirectoryResourcePermissionFE {
-                                    permission_id: permission_id.clone().to_string(),
-                                    grant_type: grant_type.clone().to_string()
-                                });
-                            }
-                        }
+                if applies {
+                    for grant_type in &permission.permission_types {
+                        resource_permissions.push(DirectoryResourcePermissionFE {
+                            permission_id: permission_id.clone().to_string(),
+                            grant_type: grant_type.clone().to_string()
+                        });
                     }
                 }
-            });
+            }
         }
-    });
+    }
 
     resource_permissions
 }

--- a/src/canisters-official-backend/src/core/api/permissions/directory.rs
+++ b/src/canisters-official-backend/src/core/api/permissions/directory.rs
@@ -56,7 +56,7 @@ pub async fn check_directory_permissions(
     grantee_id: PermissionGranteeID,
 ) -> Vec<DirectoryPermissionType> {
 
-    let is_owner = OWNER_ID.with(|owner_id| UserID(grantee_id.to_string()) == *owner_id.borrow());
+    let is_owner = OWNER_ID.with(|owner_id| UserID(grantee_id.to_string()) == *owner_id.borrow().get());
 
     if is_owner {
         return vec![
@@ -316,7 +316,7 @@ pub async fn derive_directory_breadcrumbs(
     // Create a vector to hold our breadcrumbs
     let mut breadcrumbs = VecDeque::new();
 
-    let is_owner = OWNER_ID.with(|id| &id.borrow().clone() == &user_id);
+    let is_owner = OWNER_ID.with(|id| &id.borrow().get().clone() == &user_id);
     
     // Get the initial folder ID based on the resource type
     let initial_folder_id = match &resource_id {

--- a/src/canisters-official-backend/src/core/api/permissions/system.rs
+++ b/src/canisters-official-backend/src/core/api/permissions/system.rs
@@ -114,7 +114,7 @@ fn check_system_resource_permissions(
 
     // check if grantee_id is OWNER_ID, and if so then just return all permissions
     if let PermissionGranteeID::User(user_id) = grantee_id {
-        let is_owner = OWNER_ID.with(|owner_id| user_id == &*owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id == &*owner_id.borrow().get());
         if is_owner {
             let mut owner_permissions = HashSet::new();
             owner_permissions.insert(SystemPermissionType::Create);

--- a/src/canisters-official-backend/src/core/api/permissions/system.rs
+++ b/src/canisters-official-backend/src/core/api/permissions/system.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use crate::{core::{api::{internals::drive_internals::is_user_in_group, types::DirectoryIDError}, state::{drives::state::state::OWNER_ID, groups::{state::state::{is_user_on_local_group, GROUPS_BY_ID_HASHTABLE, GROUPS_BY_TIME_LIST}, types::GroupID}, permissions::{state::state::{SYSTEM_PERMISSIONS_BY_ID_HASHTABLE, SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE}, types::{PermissionGranteeID, PermissionMetadataContent, PermissionMetadataTypeEnum, PlaceholderPermissionGranteeID, SystemPermission, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum, PUBLIC_GRANTEE_ID}}}, types::UserID}, debug_log};
+use crate::{core::{api::{internals::drive_internals::is_user_in_group, types::DirectoryIDError}, state::{drives::state::state::OWNER_ID, groups::{state::state::{is_user_on_local_group, GROUPS_BY_ID_HASHTABLE, GROUPS_BY_TIME_LIST}, types::GroupID}, permissions::{state::{helpers::{get_system_permission_by_id, get_system_permission_ids_for_resource}, state::{SYSTEM_PERMISSIONS_BY_ID_HASHTABLE, SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE}}, types::{PermissionGranteeID, PermissionMetadataContent, PermissionMetadataTypeEnum, PlaceholderPermissionGranteeID, SystemPermission, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum, PUBLIC_GRANTEE_ID}}}, types::UserID}, debug_log};
 
 use super::directory::parse_permission_grantee_id;
 
@@ -120,7 +120,7 @@ fn check_system_resource_permissions(
 ) -> HashSet<SystemPermissionType> {
     let mut permissions_set = HashSet::new();
 
-    // check if grantee_id is OWNER_ID, and if so then just return all permissions
+    // Check if grantee_id is OWNER_ID, and if so then just return all permissions
     if let PermissionGranteeID::User(user_id) = grantee_id {
         let is_owner = OWNER_ID.with(|owner_id| user_id == &*owner_id.borrow().get());
         if is_owner {
@@ -134,65 +134,60 @@ fn check_system_resource_permissions(
         }
     }
     
-    // Get all permission IDs for this resource
-    SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|permissions_by_resource| {
-        if let Some(permission_ids) = permissions_by_resource.borrow().get(resource_id) {
-            // Check each permission
-            SYSTEM_PERMISSIONS_BY_ID_HASHTABLE.with(|permissions_by_id| {
-                let permissions = permissions_by_id.borrow();
-                
-                for permission_id in permission_ids {
-                    if let Some(permission) = permissions.get(permission_id) {
-                        // Skip if permission is expired or not yet active
-                        let current_time = ic_cdk::api::time() as i64;
-                        if permission.expiry_date_ms > 0 && permission.expiry_date_ms <= current_time {
-                            continue;
+    // Get all permission IDs for this resource using helper
+    if let Some(permission_ids) = get_system_permission_ids_for_resource(resource_id) {
+        // Check each permission
+        for permission_id in &permission_ids.permissions {
+            // Get permission details using helper
+            if let Some(permission) = get_system_permission_by_id(permission_id) {
+                // Skip if permission is expired or not yet active
+                let current_time = (ic_cdk::api::time() / 1_000_000) as i64;
+                if permission.expiry_date_ms > 0 && permission.expiry_date_ms <= current_time {
+                    continue;
+                }
+                if permission.begin_date_ms > 0 && permission.begin_date_ms > current_time {
+                    continue;
+                }
+
+                let permission_granted_to = match parse_permission_grantee_id(&permission.granted_to.to_string()) {
+                    Ok(parsed_grantee) => parsed_grantee,
+                    Err(_) => continue, // Skip if parsing fails
+                };
+
+                // Check if permission applies to this grantee
+                let applies = match &permission_granted_to {
+                    // If permission is public, anyone can access
+                    PermissionGranteeID::Public => true,
+                    // For other types, just match the raw IDs since we don't validate type
+                    PermissionGranteeID::User(permission_user_id) => {
+                        if let PermissionGranteeID::User(request_user_id) = grantee_id {
+                            permission_user_id.0 == request_user_id.0
+                        } else {
+                            false
                         }
-                        if permission.begin_date_ms > 0 && permission.begin_date_ms > current_time {
-                            continue;
+                    },
+                    PermissionGranteeID::Group(permission_group_id) => {
+                        if let PermissionGranteeID::Group(request_group_id) = grantee_id {
+                            permission_group_id.0 == request_group_id.0
+                        } else {
+                            false
                         }
-
-                        let permission_granted_to = match parse_permission_grantee_id(&permission.granted_to.to_string()) {
-                            Ok(parsed_grantee) => parsed_grantee,
-                            Err(_) => continue, // Skip if parsing fails
-                        };
-
-                        // Check if permission applies to this grantee
-                        let applies = match &permission_granted_to {
-                            // If permission is public, anyone can access
-                            PermissionGranteeID::Public => true,
-                            // For other types, just match the raw IDs since we don't validate type
-                            PermissionGranteeID::User(permission_user_id) => {
-                                if let PermissionGranteeID::User(request_user_id) = grantee_id {
-                                    permission_user_id.0 == request_user_id.0
-                                } else {
-                                    false
-                                }
-                            },
-                            PermissionGranteeID::Group(permission_group_id) => {
-                                if let PermissionGranteeID::Group(request_group_id) = grantee_id {
-                                    permission_group_id.0 == request_group_id.0
-                                } else {
-                                    false
-                                }
-                            },
-                            PermissionGranteeID::PlaceholderDirectoryPermissionGrantee(permission_link_id) => {
-                                if let PermissionGranteeID::PlaceholderDirectoryPermissionGrantee(request_link_id) = grantee_id {
-                                    permission_link_id.0 == request_link_id.0
-                                } else {
-                                    false
-                                }
-                            }
-                        };
-
-                        if applies {
-                            permissions_set.extend(permission.permission_types.iter().cloned());
+                    },
+                    PermissionGranteeID::PlaceholderDirectoryPermissionGrantee(permission_link_id) => {
+                        if let PermissionGranteeID::PlaceholderDirectoryPermissionGrantee(request_link_id) = grantee_id {
+                            permission_link_id.0 == request_link_id.0
+                        } else {
+                            false
                         }
                     }
+                };
+
+                if applies {
+                    permissions_set.extend(permission.permission_types.iter().cloned());
                 }
-            });
+            }
         }
-    });
+    }
     
     permissions_set
 }
@@ -268,87 +263,82 @@ fn check_system_resource_permissions_labels_internal(
 ) -> HashSet<SystemPermissionType> {
     let mut permissions_set = HashSet::new();
     
-    // Get all permission IDs for this resource
-    SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|permissions_by_resource| {
-        if let Some(permission_ids) = permissions_by_resource.borrow().get(resource_id) {
-            // Check each permission
-            SYSTEM_PERMISSIONS_BY_ID_HASHTABLE.with(|permissions_by_id| {
-                let permissions = permissions_by_id.borrow();
-                
-                for permission_id in permission_ids {
-                    if let Some(permission) = permissions.get(permission_id) {
-                        // Skip if permission is expired or not yet active
-                        let current_time = ic_cdk::api::time() as i64;
-                        if permission.expiry_date_ms > 0 && permission.expiry_date_ms <= current_time {
-                            continue;
+    // Get all permission IDs for this resource using helper
+    if let Some(permission_ids) = get_system_permission_ids_for_resource(resource_id) {
+        // Check each permission
+        for permission_id in &permission_ids.permissions {
+            // Get permission details using helper
+            if let Some(permission) = get_system_permission_by_id(permission_id) {
+                // Skip if permission is expired or not yet active
+                let current_time = (ic_cdk::api::time() / 1_000_000) as i64;
+                if permission.expiry_date_ms > 0 && permission.expiry_date_ms <= current_time {
+                    continue;
+                }
+                if permission.begin_date_ms > 0 && permission.begin_date_ms > current_time {
+                    continue;
+                }
+
+                let permission_granted_to = match parse_permission_grantee_id(&permission.granted_to.to_string()) {
+                    Ok(parsed_grantee) => parsed_grantee,
+                    Err(_) => continue, // Skip if parsing fails
+                };
+
+                // Check if permission applies to this grantee
+                let applies = match &permission_granted_to {
+                    // If permission is public, anyone can access
+                    PermissionGranteeID::Public => true,
+                    // For other types, just match the raw IDs since we don't validate type
+                    PermissionGranteeID::User(permission_user_id) => {
+                        if let PermissionGranteeID::User(request_user_id) = grantee_id {
+                            permission_user_id.0 == request_user_id.0
+                        } else {
+                            false
                         }
-                        if permission.begin_date_ms > 0 && permission.begin_date_ms > current_time {
-                            continue;
+                    },
+                    PermissionGranteeID::Group(permission_group_id) => {
+                        if let PermissionGranteeID::Group(request_group_id) = grantee_id {
+                            permission_group_id.0 == request_group_id.0
+                        } else {
+                            false
                         }
-
-                        let permission_granted_to = match parse_permission_grantee_id(&permission.granted_to.to_string()) {
-                            Ok(parsed_grantee) => parsed_grantee,
-                            Err(_) => continue, // Skip if parsing fails
-                        };
-
-                        // Check if permission applies to this grantee
-                        let applies = match &permission_granted_to {
-                            // If permission is public, anyone can access
-                            PermissionGranteeID::Public => true,
-                            // For other types, just match the raw IDs since we don't validate type
-                            PermissionGranteeID::User(permission_user_id) => {
-                                if let PermissionGranteeID::User(request_user_id) = grantee_id {
-                                    permission_user_id.0 == request_user_id.0
-                                } else {
-                                    false
-                                }
-                            },
-                            PermissionGranteeID::Group(permission_group_id) => {
-                                if let PermissionGranteeID::Group(request_group_id) = grantee_id {
-                                    permission_group_id.0 == request_group_id.0
-                                } else {
-                                    false
-                                }
-                            },
-                            PermissionGranteeID::PlaceholderDirectoryPermissionGrantee(permission_link_id) => {
-                                if let PermissionGranteeID::PlaceholderDirectoryPermissionGrantee(request_link_id) = grantee_id {
-                                    permission_link_id.0 == request_link_id.0
-                                } else {
-                                    false
-                                }
-                            }
-                        };
-
-                        if applies {
-                            // Check if there's metadata and it's a label prefix match
-                            let label_match = match &permission.metadata {
-                                Some(metadata) => {
-                                    if metadata.metadata_type == PermissionMetadataTypeEnum::Labels {
-                                        match &metadata.content {
-                                            PermissionMetadataContent::Labels(prefix) => {
-                                                // Case insensitive prefix check
-                                                label_string_value.to_lowercase()
-                                                    .starts_with(&prefix.0.to_lowercase())
-                                            },
-                                            _ => false
-                                        }
-                                    } else {
-                                        false
-                                    }
-                                },
-                                None => true
-                            };
-
-                            // If there's a label match, add the permission types
-                            if label_match {
-                                permissions_set.extend(permission.permission_types.iter().cloned());
-                            }
+                    },
+                    PermissionGranteeID::PlaceholderDirectoryPermissionGrantee(permission_link_id) => {
+                        if let PermissionGranteeID::PlaceholderDirectoryPermissionGrantee(request_link_id) = grantee_id {
+                            permission_link_id.0 == request_link_id.0
+                        } else {
+                            false
                         }
                     }
+                };
+
+                if applies {
+                    // Check if there's metadata and it's a label prefix match
+                    let label_match = match &permission.metadata {
+                        Some(metadata) => {
+                            if metadata.metadata_type == PermissionMetadataTypeEnum::Labels {
+                                match &metadata.content {
+                                    PermissionMetadataContent::Labels(prefix) => {
+                                        // Case insensitive prefix check
+                                        label_string_value.to_lowercase()
+                                            .starts_with(&prefix.0.to_lowercase())
+                                    },
+                                    _ => false
+                                }
+                            } else {
+                                false
+                            }
+                        },
+                        None => true
+                    };
+
+                    // If there's a label match, add the permission types
+                    if label_match {
+                        permissions_set.extend(permission.permission_types.iter().cloned());
+                    }
                 }
-            });
+            }
         }
-    });
+    }
     
     permissions_set
 }

--- a/src/canisters-official-backend/src/core/api/replay/diff.rs
+++ b/src/canisters-official-backend/src/core/api/replay/diff.rs
@@ -1,5 +1,6 @@
 // src/core/api/replay/diff.rs
 
+use candid::CandidType;
 use serde_diff::Apply;
 use serde_diff::{Diff, SerdeDiff};
 use serde::{Serialize, Deserialize};
@@ -12,7 +13,7 @@ use crate::core::types::{ICPPrincipalString, PublicKeyEVM};
 use crate::{core::{api::{webhooks::state_diffs::{fire_state_diff_webhooks, get_active_state_diff_webhooks}}, state::{api_keys::{state::state::{APIKEYS_BY_ID_HASHTABLE, APIKEYS_BY_VALUE_HASHTABLE, USERS_APIKEYS_HASHTABLE}, types::{ApiKey, ApiKeyID, ApiKeyValue}}, contacts::{state::state::{CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE, CONTACTS_BY_ID_HASHTABLE, CONTACTS_BY_TIME_LIST}, types::Contact}, directory::{state::state::{file_uuid_to_metadata, folder_uuid_to_metadata, full_file_path_to_uuid, full_folder_path_to_uuid}, types::{DriveFullFilePath, FileRecord, FileID, FolderRecord, FolderID}}, disks::{state::state::{DISKS_BY_ID_HASHTABLE, DISKS_BY_TIME_LIST}, types::{Disk, DiskID}}, drives::{state::state::{CANISTER_ID, DRIVES_BY_ID_HASHTABLE, DRIVES_BY_TIME_LIST, DRIVE_ID, DRIVE_STATE_TIMESTAMP_NS, OWNER_ID, URL_ENDPOINT}, types::{Drive, DriveID, DriveRESTUrlEndpoint, DriveStateDiffString}}, permissions::{state::state::{DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE, DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE, DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE, DIRECTORY_PERMISSIONS_BY_TIME_LIST, SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE, SYSTEM_PERMISSIONS_BY_ID_HASHTABLE, SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE, SYSTEM_PERMISSIONS_BY_TIME_LIST}, types::{DirectoryPermission, DirectoryPermissionID, PermissionGranteeID, SystemPermission, SystemPermissionID, SystemResourceID}}, group_invites::{state::state::{INVITES_BY_ID_HASHTABLE, USERS_INVITES_LIST_HASHTABLE}, types::{GroupInviteID, GroupInviteeID, GroupInvite}}, groups::{state::state::{GROUPS_BY_ID_HASHTABLE, GROUPS_BY_TIME_LIST}, types::{Group, GroupID}}, webhooks::{state::state::{WEBHOOKS_BY_ALT_INDEX_HASHTABLE, WEBHOOKS_BY_ID_HASHTABLE, WEBHOOKS_BY_TIME_LIST}, types::{Webhook, WebhookAltIndexID, WebhookID}}}, types::{PublicKeyICP, UserID}}, rest::directory::types::DirectoryResourceID};
 
 // Define a type to represent the entire state
-#[derive(SerdeDiff, Serialize, Deserialize, Clone, Debug)]
+#[derive(SerdeDiff, Serialize, Deserialize, Clone, Debug, CandidType)]
 pub struct EntireState {
     // About
     DRIVE_ID: DriveID,

--- a/src/canisters-official-backend/src/core/api/replay/diff.rs
+++ b/src/canisters-official-backend/src/core/api/replay/diff.rs
@@ -10,6 +10,7 @@ use crate::core::state::contacts::state::state::HISTORY_SUPERSWAP_USERID;
 use crate::core::state::drives::state::state::{DRIVE_STATE_CHECKSUM, EXTERNAL_ID_MAPPINGS, NONCE_UUID_GENERATED, RECENT_DEPLOYMENTS, SPAWN_NOTE, SPAWN_REDEEM_CODE, UUID_CLAIMED, VERSION};
 use crate::core::state::drives::types::{DriveStateDiffID, ExternalID, FactorySpawnHistoryRecord, SpawnRedeemCode, StateChecksum, StateDiffRecord, StringVec};
 use crate::core::state::group_invites::types::GroupInviteIDList;
+use crate::core::state::permissions::types::{DirectoryPermissionIDList, SystemPermissionIDList};
 use crate::core::state::webhooks::types::WebhookIDList;
 use crate::core::types::{ICPPrincipalString, PublicKeyEVM};
 use crate::{core::{api::{webhooks::state_diffs::{fire_state_diff_webhooks, get_active_state_diff_webhooks}}, state::{api_keys::{state::state::{APIKEYS_BY_ID_HASHTABLE, APIKEYS_BY_VALUE_HASHTABLE, USERS_APIKEYS_HASHTABLE}, types::{ApiKey, ApiKeyID, ApiKeyValue}}, contacts::{state::state::{CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE, CONTACTS_BY_ID_HASHTABLE, CONTACTS_BY_TIME_LIST}, types::Contact}, directory::{state::state::{file_uuid_to_metadata, folder_uuid_to_metadata, full_file_path_to_uuid, full_folder_path_to_uuid}, types::{DriveFullFilePath, FileRecord, FileID, FolderRecord, FolderID}}, disks::{state::state::{DISKS_BY_ID_HASHTABLE, DISKS_BY_TIME_LIST}, types::{Disk, DiskID}}, drives::{state::state::{CANISTER_ID, DRIVES_BY_ID_HASHTABLE, DRIVES_BY_TIME_LIST, DRIVE_ID, DRIVE_STATE_TIMESTAMP_NS, OWNER_ID, URL_ENDPOINT}, types::{Drive, DriveID, DriveRESTUrlEndpoint, DriveStateDiffString}}, permissions::{state::state::{DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE, DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE, DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE, DIRECTORY_PERMISSIONS_BY_TIME_LIST, SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE, SYSTEM_PERMISSIONS_BY_ID_HASHTABLE, SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE, SYSTEM_PERMISSIONS_BY_TIME_LIST}, types::{DirectoryPermission, DirectoryPermissionID, PermissionGranteeID, SystemPermission, SystemPermissionID, SystemResourceID}}, group_invites::{state::state::{INVITES_BY_ID_HASHTABLE, USERS_INVITES_LIST_HASHTABLE}, types::{GroupInviteID, GroupInviteeID, GroupInvite}}, groups::{state::state::{GROUPS_BY_ID_HASHTABLE, GROUPS_BY_TIME_LIST}, types::{Group, GroupID}}, webhooks::{state::state::{WEBHOOKS_BY_ALT_INDEX_HASHTABLE, WEBHOOKS_BY_ID_HASHTABLE, WEBHOOKS_BY_TIME_LIST}, types::{Webhook, WebhookAltIndexID, WebhookID}}}, types::{PublicKeyICP, UserID}}, rest::directory::types::DirectoryResourceID};
@@ -320,14 +321,98 @@ pub fn snapshot_entire_state() -> EntireState {
             vec
         }),
         // Permissions
-        DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE: DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE.with(|store| store.borrow().clone()),
-        DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE: DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|store| store.borrow().clone()),
-        DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE: DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE.with(|store| store.borrow().clone()),
-        DIRECTORY_PERMISSIONS_BY_TIME_LIST: DIRECTORY_PERMISSIONS_BY_TIME_LIST.with(|store| store.borrow().clone()),
-        SYSTEM_PERMISSIONS_BY_ID_HASHTABLE: SYSTEM_PERMISSIONS_BY_ID_HASHTABLE.with(|store| store.borrow().clone()),
-        SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE: SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|store| store.borrow().clone()),
-        SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE: SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE.with(|store| store.borrow().clone()),
-        SYSTEM_PERMISSIONS_BY_TIME_LIST: SYSTEM_PERMISSIONS_BY_TIME_LIST.with(|store| store.borrow().clone()),
+        DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE: DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE.with(|store| {
+            let btree = store.borrow();
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in btree.keys() {
+                if let Some(value) = btree.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.clone());
+                }
+            }
+            
+            hashmap
+        }),
+        DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE: DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|store| {
+            let btree = store.borrow();
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in btree.keys() {
+                if let Some(value) = btree.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.permissions.clone());
+                }
+            }
+            
+            hashmap
+        }),
+        DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE: DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE.with(|store| {
+            let btree = store.borrow();
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in btree.keys() {
+                if let Some(value) = btree.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.permissions.clone());
+                }
+            }
+            
+            hashmap
+        }),
+        DIRECTORY_PERMISSIONS_BY_TIME_LIST: DIRECTORY_PERMISSIONS_BY_TIME_LIST.with(|store| {
+            store.borrow().permissions.clone()
+        }),
+        SYSTEM_PERMISSIONS_BY_ID_HASHTABLE: SYSTEM_PERMISSIONS_BY_ID_HASHTABLE.with(|store| {
+            let btree = store.borrow();
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in btree.keys() {
+                if let Some(value) = btree.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.clone());
+                }
+            }
+            
+            hashmap
+        }),
+        SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE: SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|store| {
+            let btree = store.borrow();
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in btree.keys() {
+                if let Some(value) = btree.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.permissions.clone());
+                }
+            }
+            
+            hashmap
+        }),
+        SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE: SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE.with(|store| {
+            let btree = store.borrow();
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in btree.keys() {
+                if let Some(value) = btree.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.permissions.clone());
+                }
+            }
+            
+            hashmap
+        }),
+        SYSTEM_PERMISSIONS_BY_TIME_LIST: SYSTEM_PERMISSIONS_BY_TIME_LIST.with(|store| {
+            let list = store.borrow();
+            let mut vec = vec![];
+            for i in 0..list.len() {
+                if let Some(item) = list.get(i) {
+                    vec.push(item.clone());
+                }
+            }
+            vec
+        }),
+        
         // Group Invites
         INVITES_BY_ID_HASHTABLE: INVITES_BY_ID_HASHTABLE.with(|store| {
             let btree = store.borrow();
@@ -772,29 +857,111 @@ pub fn apply_entire_state(state: EntireState) {
     
     // Permissions
     DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE.with(|store| {
-        *store.borrow_mut() = state.DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE;
+        let mut btree = store.borrow_mut();
+        
+        // Clear existing entries
+        for key in btree.keys().collect::<Vec<_>>() {
+            btree.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE {
+            btree.insert(key, value);
+        }
     });
     DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|store| {
-        *store.borrow_mut() = state.DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE;
+        let mut btree = store.borrow_mut();
+        
+        // Clear existing entries
+        for key in btree.keys().collect::<Vec<_>>() {
+            btree.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE {
+            btree.insert(key, DirectoryPermissionIDList { permissions: value });
+        }
     });
     DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE.with(|store| {
-        *store.borrow_mut() = state.DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE;
+        let mut btree = store.borrow_mut();
+        
+        // Clear existing entries
+        for key in btree.keys().collect::<Vec<_>>() {
+            btree.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE {
+            btree.insert(key, DirectoryPermissionIDList { permissions: value });
+        }
     });
     DIRECTORY_PERMISSIONS_BY_TIME_LIST.with(|store| {
-        *store.borrow_mut() = state.DIRECTORY_PERMISSIONS_BY_TIME_LIST;
+        let mut dir_perm_list = store.borrow_mut();
+        
+        // Clear existing entries
+        while dir_perm_list.permissions.len() > 0 {
+            dir_perm_list.permissions.pop();
+        }
+        
+        // Insert new entries from Vec
+        for value in state.DIRECTORY_PERMISSIONS_BY_TIME_LIST {
+            dir_perm_list.permissions.push(value);
+        }
     });
     SYSTEM_PERMISSIONS_BY_ID_HASHTABLE.with(|store| {
-        *store.borrow_mut() = state.SYSTEM_PERMISSIONS_BY_ID_HASHTABLE;
+        let mut btree = store.borrow_mut();
+        
+        // Clear existing entries
+        for key in btree.keys().collect::<Vec<_>>() {
+            btree.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.SYSTEM_PERMISSIONS_BY_ID_HASHTABLE {
+            btree.insert(key, value);
+        }
     });
     SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|store| {
-        *store.borrow_mut() = state.SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE;
+        let mut btree = store.borrow_mut();
+        
+        // Clear existing entries
+        for key in btree.keys().collect::<Vec<_>>() {
+            btree.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE {
+            btree.insert(key, SystemPermissionIDList { permissions: value });
+        }
     });
     SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE.with(|store| {
-        *store.borrow_mut() = state.SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE;
+        let mut btree = store.borrow_mut();
+        
+        // Clear existing entries
+        for key in btree.keys().collect::<Vec<_>>() {
+            btree.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE {
+            btree.insert(key, SystemPermissionIDList { permissions: value });
+        }
     });
     SYSTEM_PERMISSIONS_BY_TIME_LIST.with(|store| {
-        *store.borrow_mut() = state.SYSTEM_PERMISSIONS_BY_TIME_LIST;
+        let mut sys_perm_list = store.borrow_mut();
+    
+        // Clear existing entries
+        while sys_perm_list.len() > 0 {
+            sys_perm_list.pop();
+        }
+    
+        // Insert new entries from Vec
+        for value in &state.SYSTEM_PERMISSIONS_BY_TIME_LIST {
+            sys_perm_list.push(value)
+                .expect("Failed to push system permission ID");
+        }
     });
+    
     
     // Group Invites
     INVITES_BY_ID_HASHTABLE.with(|store| {

--- a/src/canisters-official-backend/src/core/api/replay/diff.rs
+++ b/src/canisters-official-backend/src/core/api/replay/diff.rs
@@ -217,10 +217,54 @@ pub fn snapshot_entire_state() -> EntireState {
             hashmap
         }),
         // Directory
-        folder_uuid_to_metadata: folder_uuid_to_metadata.with(|store| store.clone()),
-        file_uuid_to_metadata: file_uuid_to_metadata.with(|store| store.clone()),
-        full_folder_path_to_uuid: full_folder_path_to_uuid.with(|store| store.clone()),
-        full_file_path_to_uuid: full_file_path_to_uuid.with(|store| store.clone()),
+        folder_uuid_to_metadata: folder_uuid_to_metadata.with(|map| {
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in map.keys() {
+                if let Some(value) = map.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.clone());
+                }
+            }
+            
+            hashmap
+        }),
+        file_uuid_to_metadata: file_uuid_to_metadata.with(|map| {
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in map.keys() {
+                if let Some(value) = map.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.clone());
+                }
+            }
+            
+            hashmap
+        }),
+        full_folder_path_to_uuid: full_folder_path_to_uuid.with(|map| {
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in map.keys() {
+                if let Some(value) = map.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.clone());
+                }
+            }
+            
+            hashmap
+        }),
+        full_file_path_to_uuid: full_file_path_to_uuid.with(|map| {
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in map.keys() {
+                if let Some(value) = map.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.clone());
+                }
+            }
+            
+            hashmap
+        }),
         // Disks
         DISKS_BY_ID_HASHTABLE: DISKS_BY_ID_HASHTABLE.with(|store| {
             let btree = store.borrow();
@@ -624,16 +668,49 @@ pub fn apply_entire_state(state: EntireState) {
     
     // Directory
     folder_uuid_to_metadata.with_mut(|map| {
-        *map = state.folder_uuid_to_metadata;
+        // Clear existing entries
+        for key in map.keys().collect::<Vec<_>>() {
+            map.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.folder_uuid_to_metadata {
+            map.insert(key, value);
+        }
     });
     file_uuid_to_metadata.with_mut(|map| {
-        *map = state.file_uuid_to_metadata;
+        // Clear existing entries
+        for key in map.keys().collect::<Vec<_>>() {
+            map.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.file_uuid_to_metadata {
+            map.insert(key, value);
+        }
     });
+    
     full_folder_path_to_uuid.with_mut(|map| {
-        *map = state.full_folder_path_to_uuid;
+        // Clear existing entries
+        for key in map.keys().collect::<Vec<_>>() {
+            map.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.full_folder_path_to_uuid {
+            map.insert(key, value);
+        }
     });
     full_file_path_to_uuid.with_mut(|map| {
-        *map = state.full_file_path_to_uuid;
+        // Clear existing entries
+        for key in map.keys().collect::<Vec<_>>() {
+            map.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.full_file_path_to_uuid {
+            map.insert(key, value);
+        }
     });
     
     // Disks

--- a/src/canisters-official-backend/src/core/api/replay/diff.rs
+++ b/src/canisters-official-backend/src/core/api/replay/diff.rs
@@ -124,10 +124,58 @@ pub fn snapshot_entire_state() -> EntireState {
             hashmap
         }),
         // Contacts
-        CONTACTS_BY_ID_HASHTABLE: CONTACTS_BY_ID_HASHTABLE.with(|store| store.borrow().clone()),
-        CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE: CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE.with(|store| store.borrow().clone()),
-        CONTACTS_BY_TIME_LIST: CONTACTS_BY_TIME_LIST.with(|store| store.borrow().clone()),
-        HISTORY_SUPERSWAP_USERID: HISTORY_SUPERSWAP_USERID.with(|store| store.borrow().clone()),
+        CONTACTS_BY_ID_HASHTABLE: CONTACTS_BY_ID_HASHTABLE.with(|store| {
+            let btree = store.borrow();
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in btree.keys() {
+                if let Some(value) = btree.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.clone());
+                }
+            }
+            
+            hashmap
+        }),
+        CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE: CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE.with(|store| {
+            let btree = store.borrow();
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in btree.keys() {
+                if let Some(value) = btree.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.clone());
+                }
+            }
+            
+            hashmap
+        }),
+        CONTACTS_BY_TIME_LIST: CONTACTS_BY_TIME_LIST.with(|store| {
+            let stable_vec = store.borrow();
+            let mut vec = Vec::new();
+            
+            // Iterate through all entries and add to Vec
+            for i in 0..stable_vec.len() {
+                if let Some(value) = stable_vec.get(i) {
+                    vec.push(value.clone());
+                }
+            }
+            
+            vec
+        }),
+        HISTORY_SUPERSWAP_USERID: HISTORY_SUPERSWAP_USERID.with(|store| {
+            let btree = store.borrow();
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in btree.keys() {
+                if let Some(value) = btree.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.clone());
+                }
+            }
+            
+            hashmap
+        }),
         // Directory
         folder_uuid_to_metadata: folder_uuid_to_metadata.with(|store| store.clone()),
         file_uuid_to_metadata: file_uuid_to_metadata.with(|store| store.clone()),
@@ -338,13 +386,56 @@ pub fn apply_entire_state(state: EntireState) {
     
     // Contacts
     CONTACTS_BY_ID_HASHTABLE.with(|store| {
-        *store.borrow_mut() = state.CONTACTS_BY_ID_HASHTABLE;
+        let mut btree = store.borrow_mut();
+        
+        // Clear existing entries
+        for key in btree.keys().collect::<Vec<_>>() {
+            btree.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.CONTACTS_BY_ID_HASHTABLE {
+            btree.insert(key, value);
+        }
     });
     CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE.with(|store| {
-        *store.borrow_mut() = state.CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE;
+        let mut btree = store.borrow_mut();
+        
+        // Clear existing entries
+        for key in btree.keys().collect::<Vec<_>>() {
+            btree.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE {
+            btree.insert(key, value);
+        }
     });
     CONTACTS_BY_TIME_LIST.with(|store| {
-        *store.borrow_mut() = state.CONTACTS_BY_TIME_LIST;
+        let mut stable_vec = store.borrow_mut();
+        
+        // Clear existing entries
+        while stable_vec.len() > 0 {
+            stable_vec.pop();
+        }
+        
+        // Insert new entries from Vec
+        for value in state.CONTACTS_BY_TIME_LIST {
+            stable_vec.push(&value);
+        }
+    });
+    HISTORY_SUPERSWAP_USERID.with(|store| {
+        let mut btree = store.borrow_mut();
+        
+        // Clear existing entries
+        for key in btree.keys().collect::<Vec<_>>() {
+            btree.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.HISTORY_SUPERSWAP_USERID {
+            btree.insert(key, value);
+        }
     });
     
     // Directory

--- a/src/canisters-official-backend/src/core/api/replay/diff.rs
+++ b/src/canisters-official-backend/src/core/api/replay/diff.rs
@@ -1,11 +1,11 @@
 // src/core/api/replay/diff.rs
 
-use candid::CandidType;
 use serde_diff::Apply;
 use serde_diff::{Diff, SerdeDiff};
 use serde::{Serialize, Deserialize};
 use std::collections::HashMap;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use crate::core::state::api_keys::types::ApiKeyIDList;
 use crate::core::state::contacts::state::state::HISTORY_SUPERSWAP_USERID;
 use crate::core::state::drives::state::state::{DRIVE_STATE_CHECKSUM, EXTERNAL_ID_MAPPINGS, NONCE_UUID_GENERATED, RECENT_DEPLOYMENTS, SPAWN_NOTE, SPAWN_REDEEM_CODE, UUID_CLAIMED};
 use crate::core::state::drives::types::{DriveStateDiffID, ExternalID, FactorySpawnHistoryRecord, SpawnRedeemCode, StateChecksum, StateDiffRecord};
@@ -13,7 +13,7 @@ use crate::core::types::{ICPPrincipalString, PublicKeyEVM};
 use crate::{core::{api::{webhooks::state_diffs::{fire_state_diff_webhooks, get_active_state_diff_webhooks}}, state::{api_keys::{state::state::{APIKEYS_BY_ID_HASHTABLE, APIKEYS_BY_VALUE_HASHTABLE, USERS_APIKEYS_HASHTABLE}, types::{ApiKey, ApiKeyID, ApiKeyValue}}, contacts::{state::state::{CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE, CONTACTS_BY_ID_HASHTABLE, CONTACTS_BY_TIME_LIST}, types::Contact}, directory::{state::state::{file_uuid_to_metadata, folder_uuid_to_metadata, full_file_path_to_uuid, full_folder_path_to_uuid}, types::{DriveFullFilePath, FileRecord, FileID, FolderRecord, FolderID}}, disks::{state::state::{DISKS_BY_ID_HASHTABLE, DISKS_BY_TIME_LIST}, types::{Disk, DiskID}}, drives::{state::state::{CANISTER_ID, DRIVES_BY_ID_HASHTABLE, DRIVES_BY_TIME_LIST, DRIVE_ID, DRIVE_STATE_TIMESTAMP_NS, OWNER_ID, URL_ENDPOINT}, types::{Drive, DriveID, DriveRESTUrlEndpoint, DriveStateDiffString}}, permissions::{state::state::{DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE, DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE, DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE, DIRECTORY_PERMISSIONS_BY_TIME_LIST, SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE, SYSTEM_PERMISSIONS_BY_ID_HASHTABLE, SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE, SYSTEM_PERMISSIONS_BY_TIME_LIST}, types::{DirectoryPermission, DirectoryPermissionID, PermissionGranteeID, SystemPermission, SystemPermissionID, SystemResourceID}}, group_invites::{state::state::{INVITES_BY_ID_HASHTABLE, USERS_INVITES_LIST_HASHTABLE}, types::{GroupInviteID, GroupInviteeID, GroupInvite}}, groups::{state::state::{GROUPS_BY_ID_HASHTABLE, GROUPS_BY_TIME_LIST}, types::{Group, GroupID}}, webhooks::{state::state::{WEBHOOKS_BY_ALT_INDEX_HASHTABLE, WEBHOOKS_BY_ID_HASHTABLE, WEBHOOKS_BY_TIME_LIST}, types::{Webhook, WebhookAltIndexID, WebhookID}}}, types::{PublicKeyICP, UserID}}, rest::directory::types::DirectoryResourceID};
 
 // Define a type to represent the entire state
-#[derive(SerdeDiff, Serialize, Deserialize, Clone, Debug, CandidType)]
+#[derive(SerdeDiff, Serialize, Deserialize, Clone, Debug)]
 pub struct EntireState {
     // About
     DRIVE_ID: DriveID,
@@ -30,7 +30,7 @@ pub struct EntireState {
     // Api Keys
     APIKEYS_BY_VALUE_HASHTABLE: HashMap<ApiKeyValue, ApiKeyID>,
     APIKEYS_BY_ID_HASHTABLE: HashMap<ApiKeyID, ApiKey>,
-    USERS_APIKEYS_HASHTABLE: HashMap<UserID, Vec<ApiKeyID>>,
+    USERS_APIKEYS_HASHTABLE: HashMap<UserID, ApiKeyIDList>,
     // Contacts
     CONTACTS_BY_ID_HASHTABLE: HashMap<UserID, Contact>,
     CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE: HashMap<ICPPrincipalString, UserID>,
@@ -83,9 +83,46 @@ pub fn snapshot_entire_state() -> EntireState {
         UUID_CLAIMED: UUID_CLAIMED.with(|store| store.borrow().clone()),
         NONCE_UUID_GENERATED: NONCE_UUID_GENERATED.with(|store| store.borrow().clone()),
         // Api Keys
-        APIKEYS_BY_VALUE_HASHTABLE: APIKEYS_BY_VALUE_HASHTABLE.with(|store| store.borrow().clone()),
-        APIKEYS_BY_ID_HASHTABLE: APIKEYS_BY_ID_HASHTABLE.with(|store| store.borrow().clone()),
-        USERS_APIKEYS_HASHTABLE: USERS_APIKEYS_HASHTABLE.with(|store| store.borrow().clone()),
+        APIKEYS_BY_VALUE_HASHTABLE: APIKEYS_BY_VALUE_HASHTABLE.with(|store| {
+            let btree = store.borrow();
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in btree.keys() {
+                if let Some(value) = btree.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.clone());
+                }
+            }
+            
+            hashmap
+        }),
+        APIKEYS_BY_ID_HASHTABLE: APIKEYS_BY_ID_HASHTABLE.with(|store| {
+            // Convert StableBTreeMap to HashMap
+            let mut hashmap = HashMap::new();
+            let btree = store.borrow();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in btree.keys() {
+                if let Some(value) = btree.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.clone());
+                }
+            }
+            
+            hashmap
+        }),
+        USERS_APIKEYS_HASHTABLE: USERS_APIKEYS_HASHTABLE.with(|store| {
+            let btree = store.borrow();
+            let mut hashmap = HashMap::new();
+            
+            // Iterate through all entries and add to HashMap
+            for key_ref in btree.keys() {
+                if let Some(value) = btree.get(&key_ref) {
+                    hashmap.insert(key_ref.clone(), value.clone());
+                }
+            }
+            
+            hashmap
+        }),
         // Contacts
         CONTACTS_BY_ID_HASHTABLE: CONTACTS_BY_ID_HASHTABLE.with(|store| store.borrow().clone()),
         CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE: CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE.with(|store| store.borrow().clone()),
@@ -260,13 +297,43 @@ pub fn apply_entire_state(state: EntireState) {
     
     // Api Keys
     APIKEYS_BY_VALUE_HASHTABLE.with(|store| {
-        *store.borrow_mut() = state.APIKEYS_BY_VALUE_HASHTABLE;
+        let mut btree = store.borrow_mut();
+        
+        // Clear existing entries
+        for key in btree.keys().collect::<Vec<_>>() {
+            btree.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.APIKEYS_BY_VALUE_HASHTABLE {
+            btree.insert(key, value);
+        }
     });
     APIKEYS_BY_ID_HASHTABLE.with(|store| {
-        *store.borrow_mut() = state.APIKEYS_BY_ID_HASHTABLE;
+        let mut btree = store.borrow_mut();
+        
+        // Clear existing entries
+        for key in btree.keys().collect::<Vec<_>>() {
+            btree.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.APIKEYS_BY_ID_HASHTABLE {
+            btree.insert(key, value);
+        }
     });
     USERS_APIKEYS_HASHTABLE.with(|store| {
-        *store.borrow_mut() = state.USERS_APIKEYS_HASHTABLE;
+        let mut btree = store.borrow_mut();
+        
+        // Clear existing entries
+        for key in btree.keys().collect::<Vec<_>>() {
+            btree.remove(&key);
+        }
+        
+        // Insert new entries from HashMap
+        for (key, value) in state.USERS_APIKEYS_HASHTABLE {
+            btree.insert(key, value);
+        }
     });
     
     // Contacts

--- a/src/canisters-official-backend/src/core/api/uuid.rs
+++ b/src/canisters-official-backend/src/core/api/uuid.rs
@@ -21,8 +21,8 @@ pub fn generate_uuidv4(prefix: IDPrefix) -> String {
     
     // Get and increment the nonce
     let nonce = NONCE_UUID_GENERATED.with(|counter| {
-        let current = *counter.borrow();
-        *counter.borrow_mut() += 1;
+        let current = *counter.borrow().get(); // Get the current value
+        counter.borrow_mut().set(current + 1); // Set the incremented value
         current
     });
 

--- a/src/canisters-official-backend/src/core/api/uuid.rs
+++ b/src/canisters-official-backend/src/core/api/uuid.rs
@@ -76,7 +76,7 @@ pub fn generate_api_key() -> String {
     let api_key_inner_value = hex::encode(hash);
 
     let api_key_proof = ApiKeyProof {
-        auth_type: AuthTypeEnum::Api_Key,
+        auth_type: AuthTypeEnum::ApiKey,
         value: ApiKeyValue(api_key_inner_value.to_string()),
     };
 

--- a/src/canisters-official-backend/src/core/api/webhooks/directory.rs
+++ b/src/canisters-official-backend/src/core/api/webhooks/directory.rs
@@ -1,6 +1,6 @@
 // src/core/api/webhooks/directory.rs
 
-use crate::{core::state::{directory::{state::state::{file_uuid_to_metadata, folder_uuid_to_metadata}, types::{FileID, FolderID}}, group_invites::types::GroupInvite, groups::{state::state::GROUPS_BY_ID_HASHTABLE, types::{Group, GroupID}}, webhooks::{state::state::{WEBHOOKS_BY_ALT_INDEX_HASHTABLE, WEBHOOKS_BY_ID_HASHTABLE}, types::{Webhook, WebhookAltIndexID, WebhookEventLabel}}}, rest::webhooks::types::{DirectoryWebhookData, FileWebhookData, FolderWebhookData}};
+use crate::{core::state::{directory::{state::state::{file_uuid_to_metadata, folder_uuid_to_metadata}, types::{FileID, FolderID}}, group_invites::types::GroupInvite, groups::{state::state::GROUPS_BY_ID_HASHTABLE, types::{Group, GroupID}}, webhooks::{state::state::{WEBHOOKS_BY_ALT_INDEX_HASHTABLE, WEBHOOKS_BY_ID_HASHTABLE}, types::{Webhook, WebhookAltIndexID, WebhookEventLabel, WebhookIDList}}}, rest::webhooks::types::{DirectoryWebhookData, FileWebhookData, FolderWebhookData}};
 use crate::rest::webhooks::types::{
     WebhookEventPayload, 
     WebhookEventData, 
@@ -26,15 +26,17 @@ pub fn get_active_file_webhooks(
     let webhook_ids = WEBHOOKS_BY_ALT_INDEX_HASHTABLE.with(|store| {
         store.borrow()
             .get(&WebhookAltIndexID(file_id.0.clone()))
-            .cloned()
-            .unwrap_or_default()
+            .map(|list| list.clone())
+            .unwrap_or(WebhookIDList {
+                webhooks: [].to_vec()
+            })
     });
 
     WEBHOOKS_BY_ID_HASHTABLE.with(|store| {
         let store = store.borrow();
         all_webhooks.extend(
-            webhook_ids.into_iter()
-                .filter_map(|id| store.get(&id).cloned())
+            webhook_ids.webhooks.into_iter()
+                .filter_map(|id| store.get(&id).clone())
                 .filter(|webhook| webhook.active && webhook.event == event)
         );
     });
@@ -85,15 +87,17 @@ pub fn get_active_file_webhooks(
             let parent_webhook_ids = WEBHOOKS_BY_ALT_INDEX_HASHTABLE.with(|store| {
                 store.borrow()
                     .get(&WebhookAltIndexID(folder_id.0.clone()))
-                    .cloned()
-                    .unwrap_or_default()
+                    .map(|list| list.clone())
+                    .unwrap_or(WebhookIDList {
+                        webhooks: [].to_vec()
+                    })
             });
 
             WEBHOOKS_BY_ID_HASHTABLE.with(|store| {
                 let store = store.borrow();
                 all_webhooks.extend(
-                    parent_webhook_ids.into_iter()
-                        .filter_map(|id| store.get(&id).cloned())
+                    parent_webhook_ids.webhooks.into_iter()
+                        .filter_map(|id| store.get(&id).clone())
                         .filter(|webhook| webhook.active && webhook.event == event)
                 );
             });
@@ -119,15 +123,17 @@ pub fn get_active_folder_webhooks(
     let webhook_ids = WEBHOOKS_BY_ALT_INDEX_HASHTABLE.with(|store| {
         store.borrow()
             .get(&WebhookAltIndexID(folder_id.0.clone()))
-            .cloned()
-            .unwrap_or_default()
+            .map(|list| list.clone())
+            .unwrap_or(WebhookIDList {
+                webhooks: [].to_vec()
+            })
     });
 
     WEBHOOKS_BY_ID_HASHTABLE.with(|store| {
         let store = store.borrow();
         all_webhooks.extend(
-            webhook_ids.into_iter()
-                .filter_map(|id| store.get(&id).cloned())
+            webhook_ids.webhooks.into_iter()
+                .filter_map(|id| store.get(&id).clone())
                 .filter(|webhook| webhook.active && webhook.event == event)
         );
     });
@@ -178,15 +184,18 @@ pub fn get_active_folder_webhooks(
             let parent_webhook_ids = WEBHOOKS_BY_ALT_INDEX_HASHTABLE.with(|store| {
                 store.borrow()
                     .get(&WebhookAltIndexID(parent_id.0.clone()))
-                    .cloned()
-                    .unwrap_or_default()
+                    .map(|list| list.clone())
+                    .unwrap_or(WebhookIDList {
+                        webhooks: [].to_vec()
+                    })
             });
 
             WEBHOOKS_BY_ID_HASHTABLE.with(|store| {
                 let store = store.borrow();
                 all_webhooks.extend(
-                    parent_webhook_ids.into_iter()
-                        .filter_map(|id| store.get(&id).cloned())
+                    parent_webhook_ids.webhooks
+                        .into_iter()
+                        .filter_map(|id| store.get(&id).clone())
                         .filter(|webhook| webhook.active && webhook.event == event)
                 );
             });

--- a/src/canisters-official-backend/src/core/api/webhooks/state_diffs.rs
+++ b/src/canisters-official-backend/src/core/api/webhooks/state_diffs.rs
@@ -42,7 +42,8 @@ pub fn fire_state_diff_webhooks(
 ) {
     let drive_state_diff_id = DriveStateDiffID(generate_uuidv4(IDPrefix::DriveStateDiffID));
     // we skip mark_claimed_uuid as that will be responsibility of the webhook, and we generaete this drive_state_diff_id on the fly anyways
-    let timestamp_ns = DRIVE_STATE_TIMESTAMP_NS.with(|ts| ts.get());
+    let timestamp_ns = DRIVE_STATE_TIMESTAMP_NS.with(|ts| *ts.borrow().get());
+
     let webhooks = get_active_state_diff_webhooks();
     
     for webhook in webhooks {
@@ -58,13 +59,13 @@ pub fn fire_state_diff_webhooks(
                 after: Some(WebhookResourceData::StateDiffs(DriveStateDiffWebhookData{ 
                     data: StateDiffRecord {
                         id: drive_state_diff_id.clone(),
-                        timestamp_ns: timestamp_ns,
+                        timestamp_ns: timestamp_ns.clone(),
                         implementation: DriveStateDiffImplementationType::RustIcpCanister,
                         diff_forward: forward_diff.clone(),
                         diff_backward: backward_diff.clone(),
                         notes: notes.clone(),
                         drive_id: DRIVE_ID.with(|id| id.clone()),
-                        endpoint_url: URL_ENDPOINT.with(|url| url.borrow().clone()),
+                        endpoint_url: URL_ENDPOINT.with(|url| url.borrow().get().clone()),
                         checksum_forward: forward_checksum.clone(),
                         checksum_backward: backward_checksum.clone(),
                     }

--- a/src/canisters-official-backend/src/core/api/webhooks/state_diffs.rs
+++ b/src/canisters-official-backend/src/core/api/webhooks/state_diffs.rs
@@ -20,14 +20,14 @@ pub fn get_active_state_diff_webhooks() -> Vec<Webhook> {
     let webhook_ids = WEBHOOKS_BY_ALT_INDEX_HASHTABLE.with(|store| {
         store.borrow()
             .get(&WebhookAltIndexID(WebhookAltIndexID::state_diffs_slug().to_string()))
-            .cloned()
+            .clone()
             .unwrap_or_default()
     });
 
     WEBHOOKS_BY_ID_HASHTABLE.with(|store| {
         let store = store.borrow();
-        webhook_ids.into_iter()
-            .filter_map(|id| store.get(&id).cloned())
+        webhook_ids.webhooks.into_iter()
+            .filter_map(|id| store.get(&id).clone())
             .filter(|webhook| webhook.active && webhook.event == WebhookEventLabel::DriveStateDiffs)
             .collect()
     })

--- a/src/canisters-official-backend/src/core/state/api_keys/state.rs
+++ b/src/canisters-official-backend/src/core/state/api_keys/state.rs
@@ -40,7 +40,7 @@ pub mod state {
         let default_key = ApiKey {
             id: ApiKeyID(generate_uuidv4(IDPrefix::ApiKey)),
             value: ApiKeyValue(generate_api_key()),
-            user_id: OWNER_ID.with(|id| id.borrow().clone()),
+            user_id: OWNER_ID.with(|id| id.borrow().get().clone()),
             name: "Default Admin Key".to_string(),
             private_note: None,
             created_at: ic_cdk::api::time(),

--- a/src/canisters-official-backend/src/core/state/api_keys/state.rs
+++ b/src/canisters-official-backend/src/core/state/api_keys/state.rs
@@ -3,44 +3,34 @@
 pub mod state {
     use std::cell::RefCell;
     use std::collections::HashMap;
-    use crate::{core::{api::uuid::{generate_api_key, generate_uuidv4}, state::{api_keys::types::{ApiKey, ApiKeyID, ApiKeyValue}, drives::state::state::OWNER_ID}, types::{IDPrefix, UserID}}, debug_log};
+    use ic_stable_structures::{memory_manager::MemoryId, StableBTreeMap, DefaultMemoryImpl};
+    use crate::{core::{api::uuid::{generate_api_key, generate_uuidv4}, state::{api_keys::types::{ApiKey, ApiKeyID, ApiKeyIDList, ApiKeyValue}, drives::state::state::OWNER_ID}, types::{IDPrefix, UserID}}, debug_log, MEMORY_MANAGER};
+
+    type Memory = ic_stable_structures::memory_manager::VirtualMemory<DefaultMemoryImpl>;
+    pub const APIKEYS_MEMORY_ID: MemoryId = MemoryId::new(4);
+    pub const APIKEYS_BY_VALUE_MEMORY_ID: MemoryId = MemoryId::new(5);
+    pub const USERS_APIKEYS_MEMORY_ID: MemoryId = MemoryId::new(6);
 
     thread_local! {
         // users pass in api key value, we O(1) lookup the api key id + O(1) lookup the api key
-        pub(crate) static APIKEYS_BY_VALUE_HASHTABLE: RefCell<HashMap<ApiKeyValue, ApiKeyID>> = RefCell::new(HashMap::new());
+        pub(crate) static APIKEYS_BY_VALUE_HASHTABLE: RefCell<StableBTreeMap<ApiKeyValue, ApiKeyID, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(APIKEYS_BY_VALUE_MEMORY_ID))
+            )
+        );
         // default is to use the api key id to lookup the api key
-        pub(crate) static APIKEYS_BY_ID_HASHTABLE: RefCell<HashMap<ApiKeyID, ApiKey>> = RefCell::new(HashMap::new());
+        // This will replace your HashMap, but keep the same name
+        pub(crate) static APIKEYS_BY_ID_HASHTABLE: RefCell<StableBTreeMap<ApiKeyID, ApiKey, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(APIKEYS_MEMORY_ID))
+            )
+        );
         // track in hashtable users list of ApiKeyIDs
-        pub(crate) static USERS_APIKEYS_HASHTABLE: RefCell<HashMap<UserID, Vec<ApiKeyID>>> = RefCell::new(HashMap::new());
-    }
-
-    // Helper functions to get debug string representations
-    pub fn debug_apikeys_by_value() -> String {
-        APIKEYS_BY_VALUE_HASHTABLE.with(|map| {
-            format!("{:#?}", map.borrow())
-        })
-    }
-
-    pub fn debug_apikeys_by_id() -> String {
-        APIKEYS_BY_ID_HASHTABLE.with(|map| {
-            format!("{:#?}", map.borrow())
-        })
-    }
-
-    pub fn debug_users_apikeys() -> String {
-        USERS_APIKEYS_HASHTABLE.with(|map| {
-            format!("{:#?}", map.borrow())
-        })
-    }
-
-    // Function to log all state
-    pub fn debug_state() -> String {
-        format!(
-            "State Debug:\n\nAPIKEYS_BY_VALUE:\n{}\n\nAPIKEYS_BY_ID:\n{}\n\nUSERS_APIKEYS:\n{}",
-            debug_apikeys_by_value(),
-            debug_apikeys_by_id(),
-            debug_users_apikeys()
-        )
+        pub(crate) static USERS_APIKEYS_HASHTABLE: RefCell<StableBTreeMap<UserID, ApiKeyIDList, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(USERS_APIKEYS_MEMORY_ID))
+            )
+        );
     }
 
     pub fn init_default_admin_apikey() {
@@ -73,7 +63,8 @@ pub mod state {
         });
 
         USERS_APIKEYS_HASHTABLE.with(|map| {
-            map.borrow_mut().insert(default_key.user_id.clone(), vec![default_key.id.clone()]);
+            let key_list = ApiKeyIDList::with_key(default_key.id.clone());
+            map.borrow_mut().insert(default_key.user_id.clone(), key_list);
         });
     }
 }

--- a/src/canisters-official-backend/src/core/state/api_keys/types.rs
+++ b/src/canisters-official-backend/src/core/state/api_keys/types.rs
@@ -1,16 +1,57 @@
 
-use candid::CandidType;
+
 // src/core/state/api_keys/types.rs
+use candid::CandidType;
+use ic_stable_structures::{storable::Bound, Storable};
 use serde_diff::{Diff, SerdeDiff};
 use serde::{Deserialize, Serialize};
 use crate::{core::{api::permissions::system::check_system_permissions, state::{contacts::state::state::CONTACTS_BY_ID_HASHTABLE, drives::{state::state::OWNER_ID, types::{ExternalID, ExternalPayload}}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}, labels::types::{redact_label, LabelStringValue}}, types::UserID}, rest::api_keys::types::ApiKeyFE};
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, PartialOrd, Ord, CandidType)]
 pub struct ApiKeyID(pub String);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+impl Storable for ApiKeyID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize ApiKeyID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize ApiKeyID")
+    }
+}
+
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, PartialOrd, Ord, CandidType)]
 pub struct ApiKeyValue(pub String);
+
+impl Storable for ApiKeyValue {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize ApiKeyValue");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize ApiKeyValue")
+    }
+}
 
 
 // Implement Display for ApiKey
@@ -21,7 +62,7 @@ impl fmt::Display for ApiKey {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, PartialOrd, Ord, PartialEq, Eq, CandidType)]
 pub struct ApiKey {
     pub id: ApiKeyID,
     pub value: ApiKeyValue,
@@ -35,6 +76,25 @@ pub struct ApiKey {
     pub labels: Vec<LabelStringValue>,
     pub external_id: Option<ExternalID>,
     pub external_payload: Option<ExternalPayload>,
+}
+
+impl Storable for ApiKey {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 64, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize ApiKeyID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize ApiKeyID")
+    }
 }
 
 
@@ -92,6 +152,71 @@ impl fmt::Display for ApiKeyValue {
     }
 }
 
+#[derive(Clone, Debug, CandidType, Deserialize, Serialize, SerdeDiff)]
+pub struct ApiKeyIDList {
+    pub keys: Vec<ApiKeyID>,
+}
+impl ApiKeyIDList {
+    pub fn new() -> Self {
+        Self { keys: Vec::new() }
+    }
+    
+    pub fn with_key(key_id: ApiKeyID) -> Self {
+        Self { keys: vec![key_id] }
+    }
+    
+    pub fn add(&mut self, key_id: ApiKeyID) {
+        self.keys.push(key_id);
+    }
+    
+    pub fn remove(&mut self, key_id: &ApiKeyID) -> bool {
+        if let Some(pos) = self.keys.iter().position(|k| k == key_id) {
+            self.keys.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+    
+    // Add iter method to satisfy the error in handler.rs
+    pub fn iter(&self) -> impl Iterator<Item = &ApiKeyID> {
+        self.keys.iter()
+    }
+    
+    // Check if the list is empty
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+}
+
+// Implement conversion between Vec<ApiKeyID> and ApiKeyIDList
+impl From<Vec<ApiKeyID>> for ApiKeyIDList {
+    fn from(keys: Vec<ApiKeyID>) -> Self {
+        Self { keys }
+    }
+}
+
+impl From<ApiKeyIDList> for Vec<ApiKeyID> {
+    fn from(list: ApiKeyIDList) -> Self {
+        list.keys
+    }
+}
+// Implement Storable for ApiKeyIDList
+impl Storable for ApiKeyIDList {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 1024 * 4, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = candid::encode_one(self).unwrap();
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).unwrap()
+    }
+}
 
     
 #[derive(Deserialize, Serialize, Clone, Copy, Debug, PartialEq, CandidType)]

--- a/src/canisters-official-backend/src/core/state/api_keys/types.rs
+++ b/src/canisters-official-backend/src/core/state/api_keys/types.rs
@@ -117,7 +117,7 @@ impl ApiKey {
             PermissionGranteeID::User(user_id.clone())
         );
         let table_permissions = check_system_permissions(
-            SystemResourceID::Table(SystemTableEnum::Api_Keys),
+            SystemResourceID::Table(SystemTableEnum::ApiKeys),
             PermissionGranteeID::User(user_id.clone())
         );
         let permission_previews: Vec<SystemPermissionType> = record_permissions

--- a/src/canisters-official-backend/src/core/state/api_keys/types.rs
+++ b/src/canisters-official-backend/src/core/state/api_keys/types.rs
@@ -1,14 +1,15 @@
 
+use candid::CandidType;
 // src/core/state/api_keys/types.rs
 use serde_diff::{Diff, SerdeDiff};
 use serde::{Deserialize, Serialize};
 use crate::{core::{api::permissions::system::check_system_permissions, state::{contacts::state::state::CONTACTS_BY_ID_HASHTABLE, drives::{state::state::OWNER_ID, types::{ExternalID, ExternalPayload}}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}, labels::types::{redact_label, LabelStringValue}}, types::UserID}, rest::api_keys::types::ApiKeyFE};
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct ApiKeyID(pub String);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct ApiKeyValue(pub String);
 
 
@@ -20,7 +21,7 @@ impl fmt::Display for ApiKey {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct ApiKey {
     pub id: ApiKeyID,
     pub value: ApiKeyValue,
@@ -93,43 +94,43 @@ impl fmt::Display for ApiKeyValue {
 
 
     
-#[derive(Deserialize, Serialize, Clone, Copy, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, PartialEq, CandidType)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum AuthTypeEnum {
     Signature,
-    Api_Key
+    ApiKey
 }
 impl fmt::Display for AuthTypeEnum {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             AuthTypeEnum::Signature => write!(f, "SIGNATURE"),
-            AuthTypeEnum::Api_Key => write!(f, "API_KEY"),
+            AuthTypeEnum::ApiKey => write!(f, "API_KEY"),
         }
     }
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, CandidType)]
 #[serde(untagged)]
 pub enum AuthJsonDecoded {
     Signature(SignatureAuthProof),
-    Api_Key(ApiKeyProof),
+    ApiKey(ApiKeyProof),
 }
 
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, CandidType)]
 pub struct ApiKeyProof {
     pub auth_type: AuthTypeEnum,
     pub value: ApiKeyValue,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, CandidType)]
 pub struct SignatureAuthProof {
     pub auth_type: AuthTypeEnum,
     pub challenge: SignatureAuthChallenge,
     pub signature: Vec<u8>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, CandidType)]
 pub struct SignatureAuthChallenge {
     pub timestamp_ms: u64,
     pub drive_canister_id: String,

--- a/src/canisters-official-backend/src/core/state/contacts/state.rs
+++ b/src/canisters-official-backend/src/core/state/contacts/state.rs
@@ -47,7 +47,7 @@ pub mod state {
     pub fn init_default_owner_contact(name: Option<String>) {
         debug_log!("Initializing default owner contact...");
 
-        let owner_id = OWNER_ID.with(|id| id.borrow().clone());
+        let owner_id = OWNER_ID.with(|id| id.borrow().get().clone());
         // extract icp principal by removing the prefix IDPrefix::User
         let owner_icp_principal = owner_id.to_icp_principal_string();
 

--- a/src/canisters-official-backend/src/core/state/contacts/state.rs
+++ b/src/canisters-official-backend/src/core/state/contacts/state.rs
@@ -3,19 +3,46 @@ pub mod state {
     use std::cell::RefCell;
     use std::collections::HashMap;
 
-    use crate::{core::{state::{contacts::types::Contact, drives::state::state::OWNER_ID}, types::{ICPPrincipalString, IDPrefix, PublicKeyICP, UserID}}, debug_log};
+    use ic_stable_structures::{memory_manager::MemoryId, BTreeMap, StableBTreeMap, StableVec, DefaultMemoryImpl, Vec};
+
+    use crate::{core::{state::{contacts::types::{Contact, ContactIDList}, drives::state::state::OWNER_ID}, types::{ICPPrincipalString, IDPrefix, PublicKeyICP, UserID}}, debug_log, MEMORY_MANAGER};
     
+    type Memory = ic_stable_structures::memory_manager::VirtualMemory<DefaultMemoryImpl>;
+    pub const CONTACTS_MEMORY_ID: MemoryId = MemoryId::new(7); 
+    pub const CONTACTS_BY_ICP_MEMORY_ID: MemoryId = MemoryId::new(8);
+    pub const CONTACTS_BY_TIME_MEMORY_ID: MemoryId = MemoryId::new(9);
+    pub const HISTORY_SUPERSWAP_MEMORY_ID: MemoryId = MemoryId::new(10);
+
     thread_local! {
-        // default is to use the api key id to lookup the api key
-        pub(crate) static CONTACTS_BY_ID_HASHTABLE: RefCell<HashMap<UserID, Contact>> = RefCell::new(HashMap::new());
-        // default is to use the api key id to lookup the api key
-        pub(crate) static CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE: RefCell<HashMap<ICPPrincipalString, UserID>> = RefCell::new(HashMap::new());
-        // track in hashtable users list of ApiKeyIDs
-        pub(crate) static CONTACTS_BY_TIME_LIST: RefCell<Vec<UserID>> = RefCell::new(Vec::new());
-        // superswap userid history
-        // HISTORY_SUPERSWAP_USERID: HashMap<OldUserID, CurrentUserID>
-        pub(crate) static HISTORY_SUPERSWAP_USERID: RefCell<HashMap<UserID, UserID>> = RefCell::new(HashMap::new());
+        // Replace HashMap with StableBTreeMap for contacts by ID
+        pub(crate) static CONTACTS_BY_ID_HASHTABLE: RefCell<StableBTreeMap<UserID, Contact, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(CONTACTS_MEMORY_ID))
+            )
+        );
+        
+        // Replace HashMap with StableBTreeMap for contacts by ICP principal
+        pub(crate) static CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE: RefCell<StableBTreeMap<ICPPrincipalString, UserID, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(CONTACTS_BY_ICP_MEMORY_ID))
+            )
+        );
+        
+        // Replace Vec with StableVec for contacts by time list
+        pub(crate) static CONTACTS_BY_TIME_LIST: RefCell<StableVec<UserID, Memory>> = RefCell::new(
+            StableVec::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(CONTACTS_BY_TIME_MEMORY_ID))
+            ).expect("Failed to initialize CONTACTS_BY_TIME_LIST")
+        );
+        
+        // Replace HashMap with StableBTreeMap for superswap history
+        pub(crate) static HISTORY_SUPERSWAP_USERID: RefCell<StableBTreeMap<UserID, UserID, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(HISTORY_SUPERSWAP_MEMORY_ID))
+            )
+        );
     }
+
 
     pub fn init_default_owner_contact(name: Option<String>) {
         debug_log!("Initializing default owner contact...");
@@ -62,7 +89,7 @@ pub mod state {
         });
 
         CONTACTS_BY_TIME_LIST.with(|list| {
-            list.borrow_mut().push(owner_id);
+            list.borrow_mut().push(&owner_id);
         });
     }
 }

--- a/src/canisters-official-backend/src/core/state/contacts/types.rs
+++ b/src/canisters-official-backend/src/core/state/contacts/types.rs
@@ -66,7 +66,7 @@ impl Contact {
             .filter_map(|group_id| {
                 // Get the group data
                 let group_opt = crate::core::state::groups::state::state::GROUPS_BY_ID_HASHTABLE
-                    .with(|groups| groups.borrow().get(group_id).cloned());
+                    .with(|groups| groups.borrow().get(group_id).clone());
                 
                 if let Some(group) = group_opt {
                     // Find user's invite in this group

--- a/src/canisters-official-backend/src/core/state/contacts/types.rs
+++ b/src/canisters-official-backend/src/core/state/contacts/types.rs
@@ -1,3 +1,4 @@
+use candid::CandidType;
 // src/core/state/contacts/types.rs
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
@@ -10,7 +11,7 @@ use crate::{core::{api::permissions::system::check_system_permissions, state::{d
 // popover: pub/priv note, email, evm/icp, labels
 // filters: search by name/icp/email, filter by labels, groups, sort by last_online_ms, created_at
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct Contact {
     pub id: UserID,
     pub name: String,

--- a/src/canisters-official-backend/src/core/state/directory/types.rs
+++ b/src/canisters-official-backend/src/core/state/directory/types.rs
@@ -147,7 +147,7 @@ impl FileRecord {
     pub async fn cast_fe(&self, user_id: &UserID) -> FileRecordFE {
         let mut file = self.clone();
 
-        let is_owner = OWNER_ID.with(|owner_id| user_id == &*owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id == &*owner_id.borrow().get());
 
         // Get user's system permissions for this contact record
         let resource_id = DirectoryResourceID::File(file.id.clone());

--- a/src/canisters-official-backend/src/core/state/directory/types.rs
+++ b/src/canisters-official-backend/src/core/state/directory/types.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use candid::CandidType;
 // src/core/state/directory/types.rs
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
@@ -7,7 +8,7 @@ use serde_diff::{SerdeDiff};
 use crate::{core::{api::permissions::{directory::{check_directory_permissions, derive_directory_breadcrumbs}, system::check_system_permissions}, state::{disks::types::{DiskID, DiskTypeEnum}, drives::{state::state::OWNER_ID, types::{DriveID, ExternalID, ExternalPayload}}, labels::types::{redact_label, LabelStringValue}, permissions::types::{DirectoryPermissionType, PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}, raw_storage::types::UploadStatus}, types::{ICPPrincipalString, UserID}}, rest::directory::types::{DirectoryResourceID, FileRecordFE, FolderRecordFE}};
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct FolderID(pub String);
 impl fmt::Display for FolderID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -15,7 +16,7 @@ impl fmt::Display for FolderID {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct FileID(pub String);
 impl fmt::Display for FileID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -23,7 +24,7 @@ impl fmt::Display for FileID {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct DriveFullFilePath(pub String);
 impl fmt::Display for DriveFullFilePath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -32,7 +33,7 @@ impl fmt::Display for DriveFullFilePath {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct DriveClippedFilePath(pub String);
 impl fmt::Display for DriveClippedFilePath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -43,7 +44,7 @@ impl fmt::Display for DriveClippedFilePath {
 
 
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, SerdeDiff)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, SerdeDiff, CandidType)]
 pub struct FolderRecord {
     pub(crate) id: FolderID,
     pub(crate) name: String,
@@ -111,7 +112,7 @@ impl FolderRecord {
 
 
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, SerdeDiff)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, SerdeDiff, CandidType)]
 pub struct FileRecord {
     pub(crate) id: FileID,
     pub(crate) name: String,
@@ -195,7 +196,7 @@ impl FileRecord {
 
 
 
-#[derive(Serialize, Deserialize, Debug, SerdeDiff)]
+#[derive(Serialize, Deserialize, Debug, SerdeDiff, CandidType)]
 pub struct PathTranslationResponse {
     pub folder: Option<FolderRecord>,
     pub file: Option<FileRecord>,
@@ -204,7 +205,7 @@ pub struct PathTranslationResponse {
 
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct ShareTrackID(pub String);
 
 impl fmt::Display for ShareTrackID {
@@ -214,7 +215,7 @@ impl fmt::Display for ShareTrackID {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub enum ShareTrackResourceID {
     File(FileID),
     Folder(FolderID)

--- a/src/canisters-official-backend/src/core/state/directory/types.rs
+++ b/src/canisters-official-backend/src/core/state/directory/types.rs
@@ -1,6 +1,7 @@
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 use candid::CandidType;
+use ic_stable_structures::{storable::Bound, Storable};
 // src/core/state/directory/types.rs
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
@@ -15,6 +16,24 @@ impl fmt::Display for FolderID {
         write!(f, "{}", self.0)
     }
 }
+impl Storable for FolderID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize FolderID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize FolderID")
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, PartialOrd, Ord)]
 pub struct FileID(pub String);
@@ -23,21 +42,74 @@ impl fmt::Display for FileID {
         write!(f, "{}", self.0)
     }
 }
+impl Storable for FileID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize FileID");
+        Cow::Owned(bytes)
+    }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize FileID")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, PartialOrd, Ord)]
 pub struct DriveFullFilePath(pub String);
 impl fmt::Display for DriveFullFilePath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
+impl Storable for DriveFullFilePath {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize DriveFullFilePath");
+        Cow::Owned(bytes)
+    }
 
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize DriveFullFilePath")
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct DriveClippedFilePath(pub String);
 impl fmt::Display for DriveClippedFilePath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+impl Storable for DriveClippedFilePath {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize DriveClippedFilePath");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize DriveClippedFilePath")
     }
 }
 
@@ -67,6 +139,25 @@ pub struct FolderRecord {
     pub(crate) shortcut_to: Option<FolderID>,
     pub(crate) external_id: Option<ExternalID>,
     pub(crate) external_payload: Option<ExternalPayload>,
+}
+
+impl Storable for FolderRecord {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize FolderRecord");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize FolderRecord")
+    }
 }
 
 
@@ -140,6 +231,25 @@ pub struct FileRecord {
     pub(crate) shortcut_to: Option<FileID>,
     pub(crate) external_id: Option<ExternalID>,
     pub(crate) external_payload: Option<ExternalPayload>,
+}
+
+impl Storable for FileRecord {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize FileRecord");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize FileRecord")
+    }
 }
 
 impl FileRecord {

--- a/src/canisters-official-backend/src/core/state/directory/types.rs
+++ b/src/canisters-official-backend/src/core/state/directory/types.rs
@@ -8,7 +8,7 @@ use serde_diff::{SerdeDiff};
 use crate::{core::{api::permissions::{directory::{check_directory_permissions, derive_directory_breadcrumbs}, system::check_system_permissions}, state::{disks::types::{DiskID, DiskTypeEnum}, drives::{state::state::OWNER_ID, types::{DriveID, ExternalID, ExternalPayload}}, labels::types::{redact_label, LabelStringValue}, permissions::types::{DirectoryPermissionType, PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}, raw_storage::types::UploadStatus}, types::{ICPPrincipalString, UserID}}, rest::directory::types::{DirectoryResourceID, FileRecordFE, FolderRecordFE}};
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, PartialOrd, Ord)]
 pub struct FolderID(pub String);
 impl fmt::Display for FolderID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -16,7 +16,7 @@ impl fmt::Display for FolderID {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, PartialOrd, Ord)]
 pub struct FileID(pub String);
 impl fmt::Display for FileID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/canisters-official-backend/src/core/state/disks/state.rs
+++ b/src/canisters-official-backend/src/core/state/disks/state.rs
@@ -3,11 +3,28 @@ pub mod state {
     use std::cell::RefCell;
     use std::collections::HashMap;
 
-    use crate::{core::{api::uuid::generate_uuidv4, state::{directory::{state::state::{folder_uuid_to_metadata, full_folder_path_to_uuid}, types::{DriveFullFilePath, FolderID, FolderRecord}}, disks::types::{Disk, DiskID, DiskTypeEnum}, drives::{state::state::{CANISTER_ID, DRIVE_ID, OWNER_ID}, types::{DriveID, ExternalID}}}, types::{ICPPrincipalString, IDPrefix, PublicKeyICP, UserID}}, debug_log};
+    use ic_stable_structures::{memory_manager::MemoryId, BTreeMap, DefaultMemoryImpl, StableBTreeMap, StableVec};
+
+    use crate::{core::{api::uuid::generate_uuidv4, state::{directory::{state::state::{folder_uuid_to_metadata, full_folder_path_to_uuid}, types::{DriveFullFilePath, FolderID, FolderRecord}}, disks::types::{Disk, DiskID, DiskTypeEnum}, drives::{state::state::{DRIVE_ID, OWNER_ID}, types::{DriveID, ExternalID}}}, types::{IDPrefix, UserID}}, debug_log, MEMORY_MANAGER};
     
+    type Memory = ic_stable_structures::memory_manager::VirtualMemory<DefaultMemoryImpl>;
+    pub const DISKS_MEMORY_ID: MemoryId = MemoryId::new(11);
+    pub const DISKS_BY_TIME_MEMORY_ID: MemoryId = MemoryId::new(12);
+
     thread_local! {
-        pub(crate) static DISKS_BY_ID_HASHTABLE: RefCell<HashMap<DiskID, Disk>> = RefCell::new(HashMap::new());
-        pub(crate) static DISKS_BY_TIME_LIST: RefCell<Vec<DiskID>> = RefCell::new(Vec::new());
+        // Replace HashMap with StableBTreeMap for disks by ID
+        pub(crate) static DISKS_BY_ID_HASHTABLE: RefCell<StableBTreeMap<DiskID, Disk, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(DISKS_MEMORY_ID))
+            )
+        );
+        
+        // Replace Vec with StableVec for disks by time list
+        pub(crate) static DISKS_BY_TIME_LIST: RefCell<StableVec<DiskID, Memory>> = RefCell::new(
+            StableVec::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(DISKS_BY_TIME_MEMORY_ID))
+            ).expect("Failed to initialize DISKS_BY_TIME_LIST")
+        );
     }
 
     pub fn init_default_disks() {
@@ -47,7 +64,7 @@ pub mod state {
         });
 
         DISKS_BY_TIME_LIST.with(|list| {
-            list.borrow_mut().push(default_canister_disk.id.clone());
+            list.borrow_mut().push(&default_canister_disk.id.clone());
         });
 
     }

--- a/src/canisters-official-backend/src/core/state/disks/state.rs
+++ b/src/canisters-official-backend/src/core/state/disks/state.rs
@@ -35,11 +35,11 @@ pub mod state {
 
 
         let owner_id = OWNER_ID.with(|owner_id| {
-            owner_id.clone()
+            owner_id.borrow().get().clone()
         });
         let (root_folder, trash_folder) = ensure_disk_root_and_trash_folder(
             &current_canister_disk_id.clone(),
-            &owner_id.borrow().clone(),
+            &owner_id,
             &DRIVE_ID.with(|id| id.clone()),
             DiskTypeEnum::IcpCanister
         );

--- a/src/canisters-official-backend/src/core/state/disks/types.rs
+++ b/src/canisters-official-backend/src/core/state/disks/types.rs
@@ -1,3 +1,4 @@
+use candid::CandidType;
 // src/core/state/disks/types.rs
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
@@ -6,7 +7,7 @@ use std::fmt;
 use crate::{core::{api::permissions::system::check_system_permissions, state::{directory::types::FolderID, drives::{state::state::OWNER_ID, types::{ExternalID, ExternalPayload}}, labels::types::{redact_label, LabelStringValue}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}}, types::UserID}, rest::{disks::types::DiskFE, labels::types::LabelFE}};
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct DiskID(pub String);
 impl fmt::Display for DiskID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -14,7 +15,7 @@ impl fmt::Display for DiskID {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct Disk {
     pub id: DiskID,
     pub name: String,
@@ -59,7 +60,7 @@ impl Disk {
 }
 
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, SerdeDiff)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, SerdeDiff, CandidType)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum DiskTypeEnum {
     BrowserCache,
@@ -81,7 +82,7 @@ impl fmt::Display for DiskTypeEnum {
 }
 
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct AwsBucketAuth {
     pub(crate) endpoint: String,
     pub(crate) access_key: String,

--- a/src/canisters-official-backend/src/core/state/disks/types.rs
+++ b/src/canisters-official-backend/src/core/state/disks/types.rs
@@ -1,13 +1,14 @@
 use candid::CandidType;
+use ic_stable_structures::{storable::Bound, Storable};
 // src/core/state/disks/types.rs
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
-use std::fmt;
+use std::{borrow::Cow, fmt};
 
 use crate::{core::{api::permissions::system::check_system_permissions, state::{directory::types::FolderID, drives::{state::state::OWNER_ID, types::{ExternalID, ExternalPayload}}, labels::types::{redact_label, LabelStringValue}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}}, types::UserID}, rest::{disks::types::DiskFE, labels::types::LabelFE}};
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, PartialOrd, Ord)]
 pub struct DiskID(pub String);
 impl fmt::Display for DiskID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -15,7 +16,27 @@ impl fmt::Display for DiskID {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
+impl Storable for DiskID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize DiskID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize DiskID")
+    }
+}
+
+
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Disk {
     pub id: DiskID,
     pub name: String,
@@ -29,6 +50,26 @@ pub struct Disk {
     pub trash_folder: FolderID,
     pub external_id: Option<ExternalID>,
     pub external_payload: Option<ExternalPayload>,
+}
+
+
+impl Storable for Disk {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize Disk");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize Disk")
+    }
 }
 
 
@@ -60,7 +101,7 @@ impl Disk {
 }
 
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, SerdeDiff, CandidType)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum DiskTypeEnum {
     BrowserCache,

--- a/src/canisters-official-backend/src/core/state/drives/state.rs
+++ b/src/canisters-official-backend/src/core/state/drives/state.rs
@@ -64,7 +64,7 @@ pub mod state {
         pub(crate) static VERSION: RefCell<StableCell<String, Memory>> = RefCell::new(
             StableCell::init(
                 MEMORY_MANAGER.with(|m| m.borrow().get(VERSION_MEMORY_ID)),
-                "OfficeX.Beta.0.0.2".to_string()
+                "OfficeX.Beta.0.0.1".to_string()
             ).expect("Failed to initialize VERSION")
         );
         

--- a/src/canisters-official-backend/src/core/state/drives/state.rs
+++ b/src/canisters-official-backend/src/core/state/drives/state.rs
@@ -9,6 +9,7 @@ pub mod state {
     use crate::core::api::replay::diff::update_checksum_for_state_diff;
     use crate::core::api::uuid::format_drive_id;
     use crate::core::api::uuid::generate_uuidv4;
+    use crate::core::state::contacts::state::state::CONTACTS_BY_TIME_LIST;
     use crate::core::state::drives::types::Drive;
     use crate::core::state::drives::types::DriveID;
     use crate::core::state::drives::types::DriveRESTUrlEndpoint;
@@ -196,11 +197,15 @@ pub mod state {
             }
         });
 
-        crate::core::state::contacts::state::state::CONTACTS_BY_TIME_LIST.with(|store| {
+        CONTACTS_BY_TIME_LIST.with(|store| {
             let mut time_list = store.borrow_mut();
             for i in 0..time_list.len() {
-                if time_list[i] == old_user_id {
-                    time_list[i] = new_user_id.clone();
+                // get() returns a cloned value, not a reference, so no need to dereference
+                if let Some(user_id) = time_list.get(i) {
+                    if user_id == old_user_id {
+                        // set() expects a reference, so pass &new_user_id
+                        time_list.set(i, &new_user_id);
+                    }
                 }
             }
         });

--- a/src/canisters-official-backend/src/core/state/drives/state.rs
+++ b/src/canisters-official-backend/src/core/state/drives/state.rs
@@ -77,7 +77,6 @@ pub mod state {
                 ic_cdk::api::time()
             ).expect("Failed to initialize DRIVE_STATE_TIMESTAMP_NS")
         );
-        // self info - mutable
         // Convert important user-related settings to stable cells
         pub(crate) static OWNER_ID: RefCell<StableCell<UserID, Memory>> = RefCell::new(
             StableCell::init(

--- a/src/canisters-official-backend/src/core/state/drives/types.rs
+++ b/src/canisters-official-backend/src/core/state/drives/types.rs
@@ -140,7 +140,7 @@ pub struct StateDiffRecord {
 
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, PartialOrd, Ord, CandidType)]
 pub struct ExternalID(pub String);
 impl fmt::Display for ExternalID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -149,7 +149,7 @@ impl fmt::Display for ExternalID {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, PartialOrd, Ord, CandidType)]
 pub struct ExternalPayload(pub String);
 impl fmt::Display for ExternalPayload {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/canisters-official-backend/src/core/state/drives/types.rs
+++ b/src/canisters-official-backend/src/core/state/drives/types.rs
@@ -1,7 +1,8 @@
 
 // src/core/state/drives/types.rs
-use std::fmt;
+use std::{borrow::Cow, fmt};
 use candid::CandidType;
+use ic_stable_structures::{storable::Bound, Storable};
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
 use crate::{core::{api::permissions::system::check_system_permissions, state::{permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}, labels::types::{redact_label, LabelStringValue}}, types::{ICPPrincipalString, PublicKeyICP, UserID}}, rest::drives::types::DriveFE};
@@ -9,13 +10,33 @@ use crate::{core::{api::permissions::system::check_system_permissions, state::{p
 use super::state::state::OWNER_ID;
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub struct DriveID(pub String);
 impl fmt::Display for DriveID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
+
+impl Storable for DriveID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize DriveID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize DriveID")
+    }
+}
+
 
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
@@ -41,6 +62,26 @@ pub struct Drive {
     pub external_id: Option<ExternalID>,
     pub external_payload: Option<ExternalPayload>,
 }   
+
+impl Storable for Drive {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize Drive");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize Drive")
+    }
+}
+
 
 impl Drive {
 
@@ -76,6 +117,31 @@ impl Drive {
 #[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct SpawnRedeemCode(pub String);
 
+impl Storable for SpawnRedeemCode {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize SpawnRedeemCode");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize SpawnRedeemCode")
+    }
+}
+impl fmt::Display for SpawnRedeemCode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+
 // Define a struct to track deployment history
 #[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct FactorySpawnHistoryRecord {
@@ -83,6 +149,26 @@ pub struct FactorySpawnHistoryRecord {
     pub drive_id: DriveID,
     pub endpoint: String,
 }
+
+impl Storable for FactorySpawnHistoryRecord {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize FactorySpawnHistoryRecord");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize FactorySpawnHistoryRecord")
+    }
+}
+
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct DriveStateDiffID(pub String);
@@ -115,6 +201,26 @@ impl fmt::Display for StateChecksum {
     }
 }
 
+impl Storable for StateChecksum {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize StateChecksum");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize StateChecksum")
+    }
+}
+
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct DriveRESTUrlEndpoint(pub String);
 impl fmt::Display for DriveRESTUrlEndpoint {
@@ -122,6 +228,26 @@ impl fmt::Display for DriveRESTUrlEndpoint {
         write!(f, "{}", self.0)
     }
 }
+
+impl Storable for DriveRESTUrlEndpoint {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize DriveRESTUrlEndpoint");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize DriveRESTUrlEndpoint")
+    }
+}
+
 
 
 #[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
@@ -148,11 +274,122 @@ impl fmt::Display for ExternalID {
     }
 }
 
+impl Storable for ExternalID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize ExternalID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize ExternalID")
+    }
+}
+
+
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, PartialOrd, Ord, CandidType)]
 pub struct ExternalPayload(pub String);
 impl fmt::Display for ExternalPayload {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl Storable for ExternalPayload {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize ExternalPayload");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize ExternalPayload")
+    }
+}
+
+
+#[derive(Clone, Debug, CandidType, Deserialize, Serialize, SerdeDiff)]
+pub struct StringVec {
+    pub items: Vec<String>,
+}
+
+impl StringVec {
+    pub fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+    
+    pub fn with_item(item: String) -> Self {
+        Self { items: vec![item] }
+    }
+    
+    pub fn push(&mut self, item: String) {
+        self.items.push(item);
+    }
+    
+    pub fn retain<F>(&mut self, f: F) 
+    where 
+        F: FnMut(&String) -> bool 
+    {
+        self.items.retain(f);
+    }
+    
+    pub fn contains(&self, item: &str) -> bool {
+        self.items.iter().any(|i| i == item)
+    }
+    
+    pub fn iter(&self) -> impl Iterator<Item = &String> {
+        self.items.iter()
+    }
+    
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+// Implement conversion between Vec<String> and StringVec
+impl From<Vec<String>> for StringVec {
+    fn from(items: Vec<String>) -> Self {
+        Self { items }
+    }
+}
+
+impl From<StringVec> for Vec<String> {
+    fn from(list: StringVec) -> Self {
+        list.items
+    }
+}
+
+// Implement Storable for StringVec
+impl Storable for StringVec {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 1024, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize StringVec");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize StringVec")
     }
 }

--- a/src/canisters-official-backend/src/core/state/drives/types.rs
+++ b/src/canisters-official-backend/src/core/state/drives/types.rs
@@ -1,6 +1,7 @@
 
 // src/core/state/drives/types.rs
 use std::fmt;
+use candid::CandidType;
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
 use crate::{core::{api::permissions::system::check_system_permissions, state::{permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}, labels::types::{redact_label, LabelStringValue}}, types::{ICPPrincipalString, PublicKeyICP, UserID}}, rest::drives::types::DriveFE};
@@ -8,7 +9,7 @@ use crate::{core::{api::permissions::system::check_system_permissions, state::{p
 use super::state::state::OWNER_ID;
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct DriveID(pub String);
 impl fmt::Display for DriveID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -17,7 +18,7 @@ impl fmt::Display for DriveID {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct InboxNotifID(pub String);
 impl fmt::Display for InboxNotifID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -26,7 +27,7 @@ impl fmt::Display for InboxNotifID {
 }
 
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct Drive {
     pub id: DriveID,
     pub name: String,
@@ -72,18 +73,18 @@ impl Drive {
 }
 
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct SpawnRedeemCode(pub String);
 
 // Define a struct to track deployment history
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct FactorySpawnHistoryRecord {
     pub owner_id: UserID,
     pub drive_id: DriveID,
     pub endpoint: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct DriveStateDiffID(pub String);
 impl fmt::Display for DriveStateDiffID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -91,7 +92,7 @@ impl fmt::Display for DriveStateDiffID {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct DriveStateDiffString(pub String);  // base64 encoded diff
 impl fmt::Display for DriveStateDiffString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -99,14 +100,14 @@ impl fmt::Display for DriveStateDiffString {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType   )]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum DriveStateDiffImplementationType {
     RustIcpCanister,
     JavascriptRuntime,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct StateChecksum(pub String);
 impl fmt::Display for StateChecksum {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -114,7 +115,7 @@ impl fmt::Display for StateChecksum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct DriveRESTUrlEndpoint(pub String);
 impl fmt::Display for DriveRESTUrlEndpoint {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -123,7 +124,7 @@ impl fmt::Display for DriveRESTUrlEndpoint {
 }
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct StateDiffRecord {
     pub id: DriveStateDiffID,
     pub timestamp_ns: u64,
@@ -139,7 +140,7 @@ pub struct StateDiffRecord {
 
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct ExternalID(pub String);
 impl fmt::Display for ExternalID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -148,7 +149,7 @@ impl fmt::Display for ExternalID {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct ExternalPayload(pub String);
 impl fmt::Display for ExternalPayload {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/canisters-official-backend/src/core/state/drives/types.rs
+++ b/src/canisters-official-backend/src/core/state/drives/types.rs
@@ -221,7 +221,7 @@ impl Storable for StateChecksum {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub struct DriveRESTUrlEndpoint(pub String);
 impl fmt::Display for DriveRESTUrlEndpoint {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/canisters-official-backend/src/core/state/group_invites/state.rs
+++ b/src/canisters-official-backend/src/core/state/group_invites/state.rs
@@ -3,11 +3,37 @@ pub mod state {
     use std::cell::RefCell;
     use std::collections::HashMap;
 
-    use crate::core::{state::group_invites::types::{GroupInviteID, GroupInviteeID, GroupInvite}, types::UserID};
+    use ic_stable_structures::{memory_manager::MemoryId, StableBTreeMap, DefaultMemoryImpl, StableVec};
+
+    use crate::{core::{state::group_invites::types::{GroupInvite, GroupInviteID, GroupInviteIDList, GroupInviteeID}, types::UserID}, MEMORY_MANAGER};
     
+    type Memory = ic_stable_structures::memory_manager::VirtualMemory<DefaultMemoryImpl>;
+
+    pub const INVITES_BY_ID_MEMORY_ID: MemoryId = MemoryId::new(28);
+    pub const INVITES_BY_TIME_MEMORY_ID: MemoryId = MemoryId::new(29);
+    pub const USERS_INVITES_LIST_MEMORY_ID: MemoryId = MemoryId::new(30);
+
     thread_local! {
-        pub(crate) static INVITES_BY_ID_HASHTABLE: RefCell<HashMap<GroupInviteID, GroupInvite>> = RefCell::new(HashMap::new());
-        pub(crate) static USERS_INVITES_LIST_HASHTABLE: RefCell<HashMap<GroupInviteeID, Vec<GroupInviteID>>> = RefCell::new(HashMap::new());
+        // Convert HashMap to StableBTreeMap for invites by ID
+        pub(crate) static INVITES_BY_ID_HASHTABLE: RefCell<StableBTreeMap<GroupInviteID, GroupInvite, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(INVITES_BY_ID_MEMORY_ID))
+            )
+        );
+        
+        // Add time-ordered list for invites (similar to other collections)
+        pub(crate) static INVITES_BY_TIME_LIST: RefCell<StableVec<GroupInviteID, Memory>> = RefCell::new(
+            StableVec::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(INVITES_BY_TIME_MEMORY_ID))
+            ).expect("Failed to initialize INVITES_BY_TIME_LIST")
+        );
+        
+        // Convert HashMap to StableBTreeMap for user invites
+        pub(crate) static USERS_INVITES_LIST_HASHTABLE: RefCell<StableBTreeMap<GroupInviteeID, GroupInviteIDList, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(USERS_INVITES_LIST_MEMORY_ID))
+            )
+        );
     }
 
 }

--- a/src/canisters-official-backend/src/core/state/group_invites/types.rs
+++ b/src/canisters-official-backend/src/core/state/group_invites/types.rs
@@ -1,6 +1,9 @@
+use std::borrow::Cow;
 use std::fmt;
 
 use candid::CandidType;
+use ic_stable_structures::storable::Bound;
+use ic_stable_structures::Storable;
 // src/core/state/group_invites/types.rs
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
@@ -14,7 +17,7 @@ use crate::core::types::{UserID};
 use crate::rest::group_invites::types::GroupInviteFE;
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, PartialOrd, Ord)]
 pub struct GroupInviteID(pub String);
 impl fmt::Display for GroupInviteID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -22,7 +25,26 @@ impl fmt::Display for GroupInviteID {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
+impl Storable for GroupInviteID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize GroupInviteID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize GroupInviteID")
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType, PartialOrd, Ord, PartialEq, Eq)]
 pub struct GroupInvite {
     pub id: GroupInviteID,
     pub group_id: GroupID,
@@ -39,6 +61,25 @@ pub struct GroupInvite {
     pub labels: Vec<LabelStringValue>,
     pub external_id: Option<ExternalID>,
     pub external_payload: Option<ExternalPayload>,
+}
+
+impl Storable for GroupInvite {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize GroupInvite");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize GroupInvite")
+    }
 }
 
 
@@ -64,7 +105,7 @@ impl GroupInvite {
         .into_iter()
         .collect();
 
-        let (group_name, group_avatar) = match crate::core::state::groups::state::state::GROUPS_BY_ID_HASHTABLE.with(|groups| groups.borrow().get(&group_invite.group_id).cloned()) {
+        let (group_name, group_avatar) = match crate::core::state::groups::state::state::GROUPS_BY_ID_HASHTABLE.with(|groups| groups.borrow().get(&group_invite.group_id).clone()) {
             Some(group) => {
                 let group_name = group.name;
                 let group_avatar = group.avatar;
@@ -129,7 +170,7 @@ impl GroupInvite {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum GroupRole {
     Admin,
@@ -137,20 +178,57 @@ pub enum GroupRole {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub struct PlaceholderGroupInviteeID(pub String);
 impl fmt::Display for PlaceholderGroupInviteeID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
+impl Storable for PlaceholderGroupInviteeID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize PlaceholderGroupInviteeID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize PlaceholderGroupInviteeID")
+    }
+}
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub enum GroupInviteeID {
     User(UserID),
     PlaceholderGroupInvitee(PlaceholderGroupInviteeID),
     Public
+}
+
+impl Storable for GroupInviteeID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize ICPPrincipalString");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize ICPPrincipalString")
+    }
 }
 impl fmt::Display for GroupInviteeID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -159,5 +237,85 @@ impl fmt::Display for GroupInviteeID {
             GroupInviteeID::PlaceholderGroupInvitee(placeholder_id) => write!(f, "{}", placeholder_id),
             GroupInviteeID::Public => write!(f, "PUBLIC"),
         }
+    }
+}
+
+
+#[derive(Clone, Debug, CandidType, Deserialize, Serialize, SerdeDiff)]
+#[derive(Default)]
+pub struct GroupInviteIDList {
+    pub invites: Vec<GroupInviteID>,
+}
+
+impl GroupInviteIDList {
+    pub fn new() -> Self {
+        Self { invites: Vec::new() }
+    }
+    
+    pub fn with_invite(invite_id: GroupInviteID) -> Self {
+        Self { invites: vec![invite_id] }
+    }
+    
+    pub fn add(&mut self, invite_id: GroupInviteID) {
+        self.invites.push(invite_id);
+    }
+    
+    pub fn remove(&mut self, invite_id: &GroupInviteID) -> bool {
+        if let Some(pos) = self.invites.iter().position(|i| i == invite_id) {
+            self.invites.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+    
+    pub fn iter(&self) -> impl Iterator<Item = &GroupInviteID> {
+        self.invites.iter()
+    }
+    
+    pub fn is_empty(&self) -> bool {
+        self.invites.is_empty()
+    }
+    
+    pub fn contains(&self, invite_id: &GroupInviteID) -> bool {
+        self.invites.contains(invite_id)
+    }
+    
+    pub fn len(&self) -> usize {
+        self.invites.len()
+    }
+    
+    pub fn get(&self, index: usize) -> Option<&GroupInviteID> {
+        self.invites.get(index)
+    }
+}
+
+// Implement conversion between Vec<GroupInviteID> and GroupInviteIDList
+impl From<Vec<GroupInviteID>> for GroupInviteIDList {
+    fn from(invites: Vec<GroupInviteID>) -> Self {
+        Self { invites }
+    }
+}
+
+impl From<GroupInviteIDList> for Vec<GroupInviteID> {
+    fn from(list: GroupInviteIDList) -> Self {
+        list.invites
+    }
+}
+
+// Implement Storable for GroupInviteIDList
+impl Storable for GroupInviteIDList {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 1024 * 4, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = candid::encode_one(self).unwrap();
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).unwrap()
     }
 }

--- a/src/canisters-official-backend/src/core/state/group_invites/types.rs
+++ b/src/canisters-official-backend/src/core/state/group_invites/types.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use candid::CandidType;
 // src/core/state/group_invites/types.rs
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
@@ -13,7 +14,7 @@ use crate::core::types::{UserID};
 use crate::rest::group_invites::types::GroupInviteFE;
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct GroupInviteID(pub String);
 impl fmt::Display for GroupInviteID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -21,7 +22,7 @@ impl fmt::Display for GroupInviteID {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct GroupInvite {
     pub id: GroupInviteID,
     pub group_id: GroupID,
@@ -128,7 +129,7 @@ impl GroupInvite {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, SerdeDiff, CandidType)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum GroupRole {
     Admin,
@@ -136,7 +137,7 @@ pub enum GroupRole {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct PlaceholderGroupInviteeID(pub String);
 impl fmt::Display for PlaceholderGroupInviteeID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -145,7 +146,7 @@ impl fmt::Display for PlaceholderGroupInviteeID {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub enum GroupInviteeID {
     User(UserID),
     PlaceholderGroupInvitee(PlaceholderGroupInviteeID),

--- a/src/canisters-official-backend/src/core/state/group_invites/types.rs
+++ b/src/canisters-official-backend/src/core/state/group_invites/types.rs
@@ -80,7 +80,7 @@ impl GroupInvite {
         let (invitee_name, invitee_avatar) = match group_invite.clone().invitee_id {
             GroupInviteeID::User(user_id) => {
                 let contact_opt = crate::core::state::contacts::state::state::CONTACTS_BY_ID_HASHTABLE
-                    .with(|contacts| contacts.borrow().get(&user_id.clone()).cloned());
+                    .with(|contacts| contacts.borrow().get(&user_id.clone()));
                 if let Some(contact) = contact_opt {
                     (contact.name, contact.avatar)
                 } else {

--- a/src/canisters-official-backend/src/core/state/groups/state.rs
+++ b/src/canisters-official-backend/src/core/state/groups/state.rs
@@ -23,7 +23,7 @@ pub mod state {
     pub fn init_default_group() {
         let admin_invite_id = GroupInviteID(generate_uuidv4(IDPrefix::GroupInvite));
         let group_id = DEFAULT_EVERYONE_GROUP.with(|group_id| group_id.borrow().clone());
-        let owner_id = OWNER_ID.with(|owner_id| owner_id.borrow().clone());
+        let owner_id = OWNER_ID.with(|owner_id| owner_id.borrow().get().clone());
         let current_time = ic_cdk::api::time() / 1_000_000;
         let default_group = Group {
             id: group_id.clone(),
@@ -37,7 +37,7 @@ pub mod state {
             created_at: current_time.clone(),
             last_modified_at: current_time.clone(),
             drive_id: DRIVE_ID.with(|drive_id| drive_id.clone()),
-            endpoint_url: URL_ENDPOINT.with(|url| url.borrow().clone()),
+            endpoint_url: URL_ENDPOINT.with(|url| url.borrow().get().clone()),
             labels: Vec::new(),
             external_id: None,
             external_payload: None,
@@ -191,7 +191,7 @@ pub mod state {
         
         if let Some(group) = group_opt {
             // If it's our own drive's group, use local validation
-            if group.endpoint_url == URL_ENDPOINT.with(|url| url.borrow().clone()) {
+            if group.endpoint_url == URL_ENDPOINT.with(|url| url.borrow().get().clone()) {
                 return is_user_on_local_group(user_id, &group);
             }
     

--- a/src/canisters-official-backend/src/core/state/groups/types.rs
+++ b/src/canisters-official-backend/src/core/state/groups/types.rs
@@ -1,7 +1,8 @@
 use candid::CandidType;
+use ic_stable_structures::{storable::Bound, Storable};
 // src/core/state/groups/types.rs
 use serde::{Serialize, Deserialize};
-use std::fmt;
+use std::{borrow::Cow, fmt};
 use crate::{core::{
     api::permissions::system::check_system_permissions, state::{drives::{state::state::OWNER_ID, types::{DriveID, DriveRESTUrlEndpoint, ExternalID, ExternalPayload}}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}, labels::types::{redact_label, LabelStringValue}, group_invites::types::{GroupInviteID, GroupInviteeID, GroupRole}}, types::UserID
 }, rest::groups::types::{GroupFE, GroupMemberPreview}};
@@ -9,10 +10,30 @@ use serde_diff::{SerdeDiff};
 use std::iter::Iterator;
 use super::state::state::is_group_admin;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub struct GroupID(pub String);
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
+impl Storable for GroupID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize GroupID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize GroupID")
+    }
+}
+
+
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd, PartialEq, Eq)]
 pub struct Group {
     pub id: GroupID,
     pub name: String,
@@ -31,6 +52,25 @@ pub struct Group {
     pub external_payload: Option<ExternalPayload>,
 }
 
+impl Storable for Group {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 1024, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize Group");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize Group")
+    }
+}
+
 impl Group {
 
     pub fn cast_fe(&self, user_id: &UserID) -> GroupFE {
@@ -41,7 +81,7 @@ impl Group {
         for invite_id in &group.member_invites {
             // Get the invite data
             let invite_opt = crate::core::state::group_invites::state::state::INVITES_BY_ID_HASHTABLE
-                .with(|invites| invites.borrow().get(invite_id).cloned());
+                .with(|invites| invites.borrow().get(invite_id).clone());
             
             if let Some(invite) = invite_opt {
                 

--- a/src/canisters-official-backend/src/core/state/groups/types.rs
+++ b/src/canisters-official-backend/src/core/state/groups/types.rs
@@ -52,7 +52,7 @@ impl Group {
                     GroupInviteeID::User(user_id) => {
                         // query the contacts hashtable by user_id to get the name
                         let contact_opt = crate::core::state::contacts::state::state::CONTACTS_BY_ID_HASHTABLE
-                            .with(|contacts| contacts.borrow().get(&user_id.clone()).cloned());
+                            .with(|contacts| contacts.borrow().get(&user_id.clone()).map(|data| data.clone()));
                         if let Some(contact) = contact_opt {
                             contact.name
                         } else {
@@ -65,7 +65,7 @@ impl Group {
                     GroupInviteeID::User(user_id) => {
                         // query the contacts hashtable by user_id to get the avatar
                         let contact_opt = crate::core::state::contacts::state::state::CONTACTS_BY_ID_HASHTABLE
-                            .with(|contacts| contacts.borrow().get(&user_id.clone()).cloned());
+                            .with(|contacts| contacts.borrow().get(&user_id.clone()).map(|data| data.clone()));
                         if let Some(contact) = contact_opt {
                             contact.avatar
                         } else {
@@ -78,7 +78,7 @@ impl Group {
                     GroupInviteeID::User(user_id) => {
                         // query the contacts hashtable by user_id to get the last_active
                         let contact_opt = crate::core::state::contacts::state::state::CONTACTS_BY_ID_HASHTABLE
-                            .with(|contacts| contacts.borrow().get(&user_id.clone()).cloned());
+                            .with(|contacts| contacts.borrow().get(&user_id.clone()).map(|data| data.clone()));
                         if let Some(contact) = contact_opt {
                             contact.last_online_ms
                         } else {

--- a/src/canisters-official-backend/src/core/state/groups/types.rs
+++ b/src/canisters-official-backend/src/core/state/groups/types.rs
@@ -1,3 +1,4 @@
+use candid::CandidType;
 // src/core/state/groups/types.rs
 use serde::{Serialize, Deserialize};
 use std::fmt;
@@ -8,10 +9,10 @@ use serde_diff::{SerdeDiff};
 use std::iter::Iterator;
 use super::state::state::is_group_admin;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct GroupID(pub String);
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct Group {
     pub id: GroupID,
     pub name: String,

--- a/src/canisters-official-backend/src/core/state/labels/state.rs
+++ b/src/canisters-official-backend/src/core/state/labels/state.rs
@@ -203,10 +203,11 @@ pub fn add_label_to_resource(resource_id: &LabelResourceID, label_value: &LabelS
         LabelResourceID::ApiKey(id) => {
             APIKEYS_BY_ID_HASHTABLE.with(|store| {
                 let mut store = store.borrow_mut();
-                if let Some(resource) = store.get_mut(id) {
+                if let Some(mut resource) = store.get(id) {
                     // Add labels field if not already present
                     if !resource.labels.iter().any(|t| t == label_value) {
                         resource.labels.push(label_value.clone());
+                        store.insert(id.clone(), resource);
                     }
                 }
             });
@@ -381,8 +382,9 @@ pub fn remove_label_from_resource(resource_id: &LabelResourceID, label_value: &L
         LabelResourceID::ApiKey(id) => {
             APIKEYS_BY_ID_HASHTABLE.with(|store| {
                 let mut store = store.borrow_mut();
-                if let Some(resource) = store.get_mut(id) {
+                if let Some(mut resource) = store.get(id) {
                     resource.labels.retain(|t| t != label_value);
+                    store.insert(id.clone(), resource);
                 }
             });
         },

--- a/src/canisters-official-backend/src/core/state/labels/state.rs
+++ b/src/canisters-official-backend/src/core/state/labels/state.rs
@@ -215,9 +215,10 @@ pub fn add_label_to_resource(resource_id: &LabelResourceID, label_value: &LabelS
         LabelResourceID::Contact(id) => {
             CONTACTS_BY_ID_HASHTABLE.with(|store| {
                 let mut store = store.borrow_mut();
-                if let Some(resource) = store.get_mut(id) {
+                if let Some(mut resource) = store.get(id) {
                     if !resource.labels.iter().any(|t| t == label_value) {
                         resource.labels.push(label_value.clone());
+                        store.insert(id.clone(), resource);
                     }
                 }
             });
@@ -391,8 +392,9 @@ pub fn remove_label_from_resource(resource_id: &LabelResourceID, label_value: &L
         LabelResourceID::Contact(id) => {
             CONTACTS_BY_ID_HASHTABLE.with(|store| {
                 let mut store = store.borrow_mut();
-                if let Some(resource) = store.get_mut(id) {
+                if let Some(mut resource) = store.get(id) {
                     resource.labels.retain(|t| t != label_value);
+                    store.insert(id.clone(), resource);
                 }
             });
         },

--- a/src/canisters-official-backend/src/core/state/labels/state.rs
+++ b/src/canisters-official-backend/src/core/state/labels/state.rs
@@ -246,9 +246,10 @@ pub fn add_label_to_resource(resource_id: &LabelResourceID, label_value: &LabelS
         LabelResourceID::Disk(id) => {
             DISKS_BY_ID_HASHTABLE.with(|store| {
                 let mut store = store.borrow_mut();
-                if let Some(resource) = store.get_mut(id) {
+                if let Some(mut resource) = store.get(id) {
                     if !resource.labels.iter().any(|t| t == label_value) {
                         resource.labels.push(label_value.clone());
+                        store.insert(id.clone(), resource);
                     }
                 }
             });
@@ -417,8 +418,9 @@ pub fn remove_label_from_resource(resource_id: &LabelResourceID, label_value: &L
         LabelResourceID::Disk(id) => {
             DISKS_BY_ID_HASHTABLE.with(|store| {
                 let mut store = store.borrow_mut();
-                if let Some(resource) = store.get_mut(id) {
+                if let Some(mut resource) = store.get(id) {
                     resource.labels.retain(|t| t != label_value);
+                    store.insert(id.clone(), resource);
                 }
             });
         },

--- a/src/canisters-official-backend/src/core/state/labels/state.rs
+++ b/src/canisters-official-backend/src/core/state/labels/state.rs
@@ -294,23 +294,29 @@ pub fn add_label_to_resource(resource_id: &LabelResourceID, label_value: &LabelS
             });
         },
         LabelResourceID::DirectoryPermission(id) => {
+            // Adding a label to directory permission
             DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE.with(|store| {
-                let mut store = store.borrow_mut();
-                if let Some(resource) = store.get_mut(id) {
-                    if !resource.labels.iter().any(|t| t == label_value) {
-                        resource.labels.push(label_value.clone());
-                        resource.last_modified_at = ic_cdk::api::time();
+                let mut store_mut = store.borrow_mut();
+                if let Some(resource) = store_mut.get(id) {
+                    let mut updated_resource = resource.clone();
+                    if !updated_resource.labels.iter().any(|t| t == label_value) {
+                        updated_resource.labels.push(label_value.clone());
+                        updated_resource.last_modified_at = ic_cdk::api::time();
+                        store_mut.insert(id.clone(), updated_resource);
                     }
                 }
             });
         },
         LabelResourceID::SystemPermission(id) => {
+            // Adding a label to system permission
             SYSTEM_PERMISSIONS_BY_ID_HASHTABLE.with(|store| {
-                let mut store = store.borrow_mut();
-                if let Some(resource) = store.get_mut(id) {
-                    if !resource.labels.iter().any(|t| t == label_value) {
-                        resource.labels.push(label_value.clone());
-                        resource.last_modified_at = ic_cdk::api::time();
+                let mut store_mut = store.borrow_mut();
+                if let Some(resource) = store_mut.get(id) {
+                    let mut updated_resource = resource.clone();
+                    if !updated_resource.labels.iter().any(|t| t == label_value) {
+                        updated_resource.labels.push(label_value.clone());
+                        updated_resource.last_modified_at = ic_cdk::api::time();
+                        store_mut.insert(id.clone(), updated_resource);
                     }
                 }
             });
@@ -472,20 +478,26 @@ pub fn remove_label_from_resource(resource_id: &LabelResourceID, label_value: &L
             });
         },
         LabelResourceID::DirectoryPermission(id) => {
+            // Removing a label from directory permission
             DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE.with(|store| {
-                let mut store = store.borrow_mut();
-                if let Some(resource) = store.get_mut(id) {
-                    resource.labels.retain(|t| t != label_value);
-                    resource.last_modified_at = ic_cdk::api::time();
+                let mut store_mut = store.borrow_mut();
+                if let Some(resource) = store_mut.get(id) {
+                    let mut updated_resource = resource.clone();
+                    updated_resource.labels.retain(|t| t != label_value);
+                    updated_resource.last_modified_at = ic_cdk::api::time();
+                    store_mut.insert(id.clone(), updated_resource);
                 }
             });
         },
         LabelResourceID::SystemPermission(id) => {
+            // Removing a label from system permission
             SYSTEM_PERMISSIONS_BY_ID_HASHTABLE.with(|store| {
-                let mut store = store.borrow_mut();
-                if let Some(resource) = store.get_mut(id) {
-                    resource.labels.retain(|t| t != label_value);
-                    resource.last_modified_at = ic_cdk::api::time();
+                let mut store_mut = store.borrow_mut();
+                if let Some(resource) = store_mut.get(id) {
+                    let mut updated_resource = resource.clone();
+                    updated_resource.labels.retain(|t| t != label_value);
+                    updated_resource.last_modified_at = ic_cdk::api::time();
+                    store_mut.insert(id.clone(), updated_resource);
                 }
             });
         },

--- a/src/canisters-official-backend/src/core/state/labels/state.rs
+++ b/src/canisters-official-backend/src/core/state/labels/state.rs
@@ -251,20 +251,22 @@ pub fn add_label_to_resource(resource_id: &LabelResourceID, label_value: &LabelS
         },
         LabelResourceID::File(id) => {
             file_uuid_to_metadata.with_mut(|files| {
-                if let Some(resource) = files.get_mut(id) {
-                    if !resource.labels.iter().any(|t| &LabelStringValue(t.0.clone()) == label_value) {
-                        resource.labels.push(LabelStringValue(label_value.0.clone()));
-                        resource.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                if let Some(mut record) = files.get(id) {
+                    if !record.labels.iter().any(|t| &LabelStringValue(t.0.clone()) == label_value) {
+                        record.labels.push(LabelStringValue(label_value.0.clone()));
+                        record.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                        files.insert(id.clone(), record); 
                     }
                 }
             });
         },
         LabelResourceID::Folder(id) => {
             folder_uuid_to_metadata.with_mut(|folders| {
-                if let Some(resource) = folders.get_mut(id) {
-                    if !resource.labels.iter().any(|t| &LabelStringValue(t.0.clone()) == label_value) {
-                        resource.labels.push(LabelStringValue(label_value.0.clone()));
-                        resource.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                if let Some(mut record) = folders.get(id) {
+                    if !record.labels.iter().any(|t| &LabelStringValue(t.0.clone()) == label_value) {
+                        record.labels.push(LabelStringValue(label_value.0.clone()));
+                        record.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                        folders.insert(id.clone(), record); 
                     }
                 }
             });
@@ -433,17 +435,19 @@ pub fn remove_label_from_resource(resource_id: &LabelResourceID, label_value: &L
         },
         LabelResourceID::File(id) => {
             file_uuid_to_metadata.with_mut(|files| {
-                if let Some(resource) = files.get_mut(id) {
-                    resource.labels.retain(|t| &LabelStringValue(t.0.clone()) != label_value);
-                    resource.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                if let Some(mut record) = files.get(id) {
+                    record.labels.retain(|t| &LabelStringValue(t.0.clone()) != label_value);
+                    record.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                    files.insert(id.clone(), record); 
                 }
             });
         },
         LabelResourceID::Folder(id) => {
             folder_uuid_to_metadata.with_mut(|folders| {
-                if let Some(resource) = folders.get_mut(id) {
-                    resource.labels.retain(|t| &LabelStringValue(t.0.clone()) != label_value);
-                    resource.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                if let Some(mut record) = folders.get(id) {
+                    record.labels.retain(|t| &LabelStringValue(t.0.clone()) != label_value);
+                    record.last_updated_date_ms = ic_cdk::api::time() / 1_000_000;
+                    folders.insert(id.clone(), record); 
                 }
             });
         },

--- a/src/canisters-official-backend/src/core/state/labels/types.rs
+++ b/src/canisters-official-backend/src/core/state/labels/types.rs
@@ -1,6 +1,7 @@
 // src/core/state/labels/types.rs
 
 use std::fmt;
+use candid::CandidType;
 use serde::{Serialize, Deserialize};
 use serde_diff::SerdeDiff;
 
@@ -21,7 +22,7 @@ use crate::{core::{
 use super::state::LABELS_BY_VALUE_HASHTABLE;
 
 // LabelID is the unique identifier for a label
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct LabelID(pub String);
 
 impl fmt::Display for LabelID {
@@ -31,7 +32,7 @@ impl fmt::Display for LabelID {
 }
 
 // LabelStringValue is the actual text of the label
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct LabelStringValue(pub String);
 
 impl fmt::Display for LabelStringValue {
@@ -41,7 +42,7 @@ impl fmt::Display for LabelStringValue {
 }
 
 // HexColorString represents a color in hex format
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct HexColorString(pub String);
 
 impl fmt::Display for HexColorString {
@@ -52,7 +53,7 @@ impl fmt::Display for HexColorString {
 
 // The main Label type that represents a label definition
 // We also dont redact labels here, for convinience. if we find this is a security issue, we can redact labels here too
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct Label {
     pub id: LabelID,
     pub value: LabelStringValue,
@@ -100,7 +101,7 @@ impl Label {
 
 
 // LabelResourceID represents any resource that can be labelged
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub enum LabelResourceID {
     ApiKey(ApiKeyID),
     Contact(UserID),
@@ -155,14 +156,14 @@ impl LabelResourceID {
 }
 
 // Request and response types for label operations
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct CreateLabelRequest {
     pub value: String,
     pub description: Option<String>,
     pub color: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct UpdateLabelRequest {
     pub id: String,
     pub value: Option<String>,
@@ -170,13 +171,13 @@ pub struct UpdateLabelRequest {
     pub color: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub enum UpsertLabelRequest {
     Create(CreateLabelRequest),
     Update(UpdateLabelRequest),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct LabelResourceRequest {
     pub label_id: String,
     pub resource_id: String,
@@ -190,14 +191,14 @@ pub struct LabelOperationResponse {
     pub label: Option<Label>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct ListLabelsRequest {
     pub query: Option<String>,
     pub page_size: Option<usize>,
     pub cursor: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, CandidType)]
 pub struct ListLabelsResponse {
     pub items: Vec<Label>,
     pub page_size: usize,
@@ -205,18 +206,18 @@ pub struct ListLabelsResponse {
     pub cursor: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct DeleteLabelRequest {
     pub id: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct DeleteLabelResponse {
     pub success: bool,
     pub id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct GetLabelResourcesRequest {
     pub label_id: String,
     pub resource_type: Option<String>,
@@ -224,7 +225,7 @@ pub struct GetLabelResourcesRequest {
     pub cursor: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct GetLabelResourcesResponse {
     pub label_id: String,
     pub resources: Vec<LabelResourceID>,

--- a/src/canisters-official-backend/src/core/state/labels/types.rs
+++ b/src/canisters-official-backend/src/core/state/labels/types.rs
@@ -32,7 +32,7 @@ impl fmt::Display for LabelID {
 }
 
 // LabelStringValue is the actual text of the label
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, PartialOrd, Ord, CandidType)]
 pub struct LabelStringValue(pub String);
 
 impl fmt::Display for LabelStringValue {

--- a/src/canisters-official-backend/src/core/state/labels/types.rs
+++ b/src/canisters-official-backend/src/core/state/labels/types.rs
@@ -242,7 +242,7 @@ pub fn redact_label(label_value: LabelStringValue, user_id: UserID) -> Option<La
     
     if let Some(label_id) = label_id {
         // Check if the user is the owner
-        let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id == owner_id.borrow().get().clone());
         
         if is_owner {
             // Owner sees everything, no redaction needed
@@ -285,7 +285,7 @@ pub fn redact_group_previews(group_preview: ContactGroupInvitePreview, user_id: 
     let group_id = &group_preview.group_id;
     
     // Check if the user is the owner
-    let is_owner = OWNER_ID.with(|owner_id| user_id == *owner_id.borrow());
+    let is_owner = OWNER_ID.with(|owner_id| user_id == owner_id.borrow().get().clone());
     
     if is_owner {
         // Owner sees everything, no redaction needed

--- a/src/canisters-official-backend/src/core/state/permissions/state.rs
+++ b/src/canisters-official-backend/src/core/state/permissions/state.rs
@@ -3,48 +3,450 @@ pub mod state {
     use std::cell::RefCell;
     use std::collections::{HashMap};
 
-    use crate::core::state::permissions::types::{SystemPermission, SystemPermissionID, SystemResourceID};
+    use ic_stable_structures::memory_manager::MemoryId;
+    use ic_stable_structures::{StableBTreeMap, DefaultMemoryImpl, StableVec};
+
+    use crate::core::state::permissions::types::{DirectoryPermissionIDList, SystemPermission, SystemPermissionID, SystemPermissionIDList, SystemResourceID};
     use crate::core::{
         state::permissions::types::{
             DirectoryPermission, DirectoryPermissionID, PermissionGranteeID
         },
     };
     use crate::rest::directory::types::DirectoryResourceID;
+    use crate::MEMORY_MANAGER;
+
+    type Memory = ic_stable_structures::memory_manager::VirtualMemory<DefaultMemoryImpl>;
+
+    pub const DIR_PERMISSIONS_MEMORY_ID: MemoryId = MemoryId::new(44);
+    pub const DIR_PERMISSIONS_BY_RESOURCE_MEMORY_ID: MemoryId = MemoryId::new(45);
+    pub const DIR_GRANTEE_PERMISSIONS_MEMORY_ID: MemoryId = MemoryId::new(46);
+    pub const DIR_PERMISSIONS_BY_TIME_MEMORY_ID: MemoryId = MemoryId::new(47);
+    
+    pub const SYS_PERMISSIONS_MEMORY_ID: MemoryId = MemoryId::new(48);
+    pub const SYS_PERMISSIONS_BY_RESOURCE_MEMORY_ID: MemoryId = MemoryId::new(49);
+    pub const SYS_GRANTEE_PERMISSIONS_MEMORY_ID: MemoryId = MemoryId::new(50);
+    pub const SYS_PERMISSIONS_BY_TIME_MEMORY_ID: MemoryId = MemoryId::new(51);
 
     thread_local! {
-        // Main storage
-        pub(crate) static DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE: RefCell<HashMap<DirectoryPermissionID, DirectoryPermission>> = 
-            RefCell::new(HashMap::new());
+        // Main storage for directory permissions
+        pub(crate) static DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE: RefCell<StableBTreeMap<DirectoryPermissionID, DirectoryPermission, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(DIR_PERMISSIONS_MEMORY_ID))
+            )
+        );
 
         // Resource-based indices for O(1) lookups
-        pub(crate) static DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE: RefCell<HashMap<DirectoryResourceID, Vec<DirectoryPermissionID>>> =
-            RefCell::new(HashMap::new());
+        pub(crate) static DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE: RefCell<StableBTreeMap<DirectoryResourceID, DirectoryPermissionIDList, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(DIR_PERMISSIONS_BY_RESOURCE_MEMORY_ID))
+            )
+        );
 
         // Grantee-based indices for O(1) lookups
-        pub(crate) static DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE: RefCell<HashMap<PermissionGranteeID, Vec<DirectoryPermissionID>>> =
-            RefCell::new(HashMap::new());
+        pub(crate) static DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE: RefCell<StableBTreeMap<PermissionGranteeID, DirectoryPermissionIDList, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(DIR_GRANTEE_PERMISSIONS_MEMORY_ID))
+            )
+        );
 
-        // Time-based indices (also used for history of one-time links)
-        pub(crate) static DIRECTORY_PERMISSIONS_BY_TIME_LIST: RefCell<Vec<DirectoryPermissionID>> = 
-            RefCell::new(Vec::new());
+        // Time-based indices
+        pub(crate) static DIRECTORY_PERMISSIONS_BY_TIME_LIST: RefCell<DirectoryPermissionIDList> = RefCell::new(
+            DirectoryPermissionIDList::new()
+        );
 
         // Main storage for system permissions
-        pub(crate) static SYSTEM_PERMISSIONS_BY_ID_HASHTABLE: RefCell<HashMap<SystemPermissionID, SystemPermission>> = 
-        RefCell::new(HashMap::new());
+        pub(crate) static SYSTEM_PERMISSIONS_BY_ID_HASHTABLE: RefCell<StableBTreeMap<SystemPermissionID, SystemPermission, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(SYS_PERMISSIONS_MEMORY_ID))
+            )
+        );
 
         // Resource-based indices for O(1) lookups
-        pub(crate) static SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE: RefCell<HashMap<SystemResourceID, Vec<SystemPermissionID>>> =
-            RefCell::new(HashMap::new());
+        pub(crate) static SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE: RefCell<StableBTreeMap<SystemResourceID, SystemPermissionIDList, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(SYS_PERMISSIONS_BY_RESOURCE_MEMORY_ID))
+            )
+        );
 
         // Grantee-based indices for O(1) lookups
-        pub(crate) static SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE: RefCell<HashMap<PermissionGranteeID, Vec<SystemPermissionID>>> =
-            RefCell::new(HashMap::new());
+        pub(crate) static SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE: RefCell<StableBTreeMap<PermissionGranteeID, SystemPermissionIDList, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(SYS_GRANTEE_PERMISSIONS_MEMORY_ID))
+            )
+        );
 
-        // Time-based indices (also used for history of one-time links)
-        pub(crate) static SYSTEM_PERMISSIONS_BY_TIME_LIST: RefCell<Vec<SystemPermissionID>> = 
-        RefCell::new(Vec::new());
-        
+        // Time-based indices
+        pub(crate) static SYSTEM_PERMISSIONS_BY_TIME_LIST: RefCell<StableVec<SystemPermissionID, Memory>> = RefCell::new(
+            StableVec::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(SYS_PERMISSIONS_BY_TIME_MEMORY_ID))
+            ).expect("Failed to initialize SYSTEM_PERMISSIONS_BY_TIME_LIST")
+        );
     }
-
 }
 
+// Helper functions for managing permissions state
+pub mod helpers {
+    use super::state::*;
+    use crate::core::state::permissions::types::{
+        DirectoryPermission, DirectoryPermissionID, DirectoryPermissionIDList, PermissionGranteeID, SystemPermission, SystemPermissionID, SystemPermissionIDList
+    };
+    use crate::rest::directory::types::DirectoryResourceID;
+    use crate::core::state::permissions::types::SystemResourceID;
+    use crate::MEMORY_MANAGER;
+    use ic_stable_structures::StableVec;
+
+    // Directory permission helpers
+
+    /// Removes a permission from the resource-indexed map
+    pub fn remove_directory_permission_from_resource(
+        resource_id: &DirectoryResourceID, 
+        permission_id: &DirectoryPermissionID
+    ) {
+        DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|permissions_by_resource| {
+            let mut permissions = permissions_by_resource.borrow_mut();
+            if let Some(current_list) = permissions.get(resource_id) {
+                let mut updated_list = DirectoryPermissionIDList::new();
+                
+                for i in 0..current_list.permissions.len() {
+                    if let Some(id) = current_list.permissions.get(i) {
+                        if id != permission_id {
+                            updated_list.add(id.clone());
+                        }
+                    }
+                }
+                
+                if updated_list.is_empty() {
+                    permissions.remove(resource_id);
+                } else {
+                    permissions.insert(resource_id.clone(), updated_list);
+                }
+            }
+        });
+    }
+
+    /// Removes a permission from the grantee-indexed map
+    pub fn remove_directory_permission_from_grantee(
+        grantee_id: &PermissionGranteeID,
+        permission_id: &DirectoryPermissionID
+    ) {
+        DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE.with(|grantee_permissions| {
+            let mut permissions = grantee_permissions.borrow_mut();
+            if let Some(current_list) = permissions.get(grantee_id) {
+                let mut updated_list = DirectoryPermissionIDList::new();
+                
+                for i in 0..current_list.permissions.len() {
+                    if let Some(id) = current_list.permissions.get(i) {
+                        if id != permission_id {
+                            updated_list.add(id.clone());
+                        }
+                    }
+                }
+                
+                if updated_list.is_empty() {
+                    permissions.remove(grantee_id);
+                } else {
+                    permissions.insert(grantee_id.clone(), updated_list);
+                }
+            }
+        });
+    }
+
+    /// Adds a permission to the resource-indexed map
+    pub fn add_directory_permission_to_resource(
+        resource_id: &DirectoryResourceID,
+        permission_id: &DirectoryPermissionID
+    ) {
+        DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|permissions_by_resource| {
+            let mut table = permissions_by_resource.borrow_mut();
+            
+            let mut resource_list = match table.get(resource_id) {
+                Some(existing_list) => {
+                    let mut list_copy = DirectoryPermissionIDList::new();
+                    for i in 0..existing_list.permissions.len() {
+                        if let Some(id) = existing_list.permissions.get(i) {
+                            list_copy.add(id.clone());
+                        }
+                    }
+                    list_copy
+                },
+                None => DirectoryPermissionIDList::new()
+            };
+            
+            resource_list.add(permission_id.clone());
+            table.insert(resource_id.clone(), resource_list);
+        });
+    }
+
+    /// Adds a permission to the grantee-indexed map
+    pub fn add_directory_permission_to_grantee(
+        grantee_id: &PermissionGranteeID,
+        permission_id: &DirectoryPermissionID
+    ) {
+        DIRECTORY_GRANTEE_PERMISSIONS_HASHTABLE.with(|grantee_permissions| {
+            let mut table = grantee_permissions.borrow_mut();
+            
+            let mut grantee_list = match table.get(grantee_id) {
+                Some(existing_list) => {
+                    let mut list_copy = DirectoryPermissionIDList::new();
+                    for i in 0..existing_list.permissions.len() {
+                        if let Some(id) = existing_list.permissions.get(i) {
+                            list_copy.add(id.clone());
+                        }
+                    }
+                    list_copy
+                },
+                None => DirectoryPermissionIDList::new()
+            };
+            
+            grantee_list.add(permission_id.clone());
+            table.insert(grantee_id.clone(), grantee_list);
+        });
+    }
+
+    /// Updates the time-indexed list of permissions
+    pub fn update_directory_permissions_time_list(
+        permission_id: &DirectoryPermissionID,
+        add: bool
+    ) {
+        DIRECTORY_PERMISSIONS_BY_TIME_LIST.with(|permissions_by_time| {
+            if add {
+                // Add to the time list
+                permissions_by_time.borrow_mut().add(permission_id.clone());
+            } else {
+                // Remove from the time list
+                let mut new_list = DirectoryPermissionIDList::new();
+                
+                let list_ref = permissions_by_time.borrow();
+                for i in 0..list_ref.permissions.len() {
+                    if let Some(id) = list_ref.permissions.get(i) {
+                        if id != permission_id {
+                            new_list.add(id.clone());
+                        }
+                    }
+                }
+                
+                drop(list_ref);
+                *permissions_by_time.borrow_mut() = new_list;
+            }
+        });
+    }
+
+    /// Gets all permission IDs for a specific directory resource
+    pub fn get_directory_permission_ids_for_resource(
+        resource_id: &DirectoryResourceID
+    ) -> Option<DirectoryPermissionIDList> {
+        let mut result = None;
+        
+        DIRECTORY_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|permissions_by_resource| {
+            if let Some(permission_ids) = permissions_by_resource.borrow().get(resource_id) {
+                result = Some(permission_ids.clone());
+            }
+        });
+        
+        result
+    }
+
+    /// Gets a directory permission by ID
+    pub fn get_directory_permission_by_id(
+        permission_id: &DirectoryPermissionID
+    ) -> Option<DirectoryPermission> {
+        let mut result = None;
+        
+        DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE.with(|permissions| {
+            if let Some(permission) = permissions.borrow().get(permission_id) {
+                result = Some(permission.clone());
+            }
+        });
+        
+        result
+    }
+
+    // System permission helpers
+
+    /// Removes a permission from the resource-indexed map
+    pub fn remove_system_permission_from_resource(
+        resource_id: &SystemResourceID, 
+        permission_id: &SystemPermissionID
+    ) {
+        SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|permissions_by_resource| {
+            let mut permissions = permissions_by_resource.borrow_mut();
+            if let Some(current_list) = permissions.get(resource_id) {
+                let mut updated_list = SystemPermissionIDList::new();
+                
+                for i in 0..current_list.permissions.len() {
+                    if let Some(id) = current_list.permissions.get(i) {
+                        if id != permission_id {
+                            updated_list.add(id.clone());
+                        }
+                    }
+                }
+                
+                if updated_list.is_empty() {
+                    permissions.remove(resource_id);
+                } else {
+                    permissions.insert(resource_id.clone(), updated_list);
+                }
+            }
+        });
+    }
+
+    /// Removes a permission from the grantee-indexed map
+    pub fn remove_system_permission_from_grantee(
+        grantee_id: &PermissionGranteeID,
+        permission_id: &SystemPermissionID
+    ) {
+        SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE.with(|grantee_permissions| {
+            let mut permissions = grantee_permissions.borrow_mut();
+            if let Some(current_list) = permissions.get(grantee_id) {
+                let mut updated_list = SystemPermissionIDList::new();
+                
+                for i in 0..current_list.permissions.len() {
+                    if let Some(id) = current_list.permissions.get(i) {
+                        if id != permission_id {
+                            updated_list.add(id.clone());
+                        }
+                    }
+                }
+                
+                if updated_list.is_empty() {
+                    permissions.remove(grantee_id);
+                } else {
+                    permissions.insert(grantee_id.clone(), updated_list);
+                }
+            }
+        });
+    }
+
+    /// Adds a permission to the resource-indexed map
+    pub fn add_system_permission_to_resource(
+        resource_id: &SystemResourceID,
+        permission_id: &SystemPermissionID
+    ) {
+        SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|permissions_by_resource| {
+            let mut table = permissions_by_resource.borrow_mut();
+            
+            let mut resource_list = match table.get(resource_id) {
+                Some(existing_list) => {
+                    let mut list_copy = SystemPermissionIDList::new();
+                    for i in 0..existing_list.permissions.len() {
+                        if let Some(id) = existing_list.permissions.get(i) {
+                            list_copy.add(id.clone());
+                        }
+                    }
+                    list_copy
+                },
+                None => SystemPermissionIDList::new()
+            };
+            
+            resource_list.add(permission_id.clone());
+            table.insert(resource_id.clone(), resource_list);
+        });
+    }
+
+    /// Adds a permission to the grantee-indexed map
+    pub fn add_system_permission_to_grantee(
+        grantee_id: &PermissionGranteeID,
+        permission_id: &SystemPermissionID
+    ) {
+        SYSTEM_GRANTEE_PERMISSIONS_HASHTABLE.with(|grantee_permissions| {
+            let mut table = grantee_permissions.borrow_mut();
+            
+            let mut grantee_list = match table.get(grantee_id) {
+                Some(existing_list) => {
+                    let mut list_copy = SystemPermissionIDList::new();
+                    for i in 0..existing_list.permissions.len() {
+                        if let Some(id) = existing_list.permissions.get(i) {
+                            list_copy.add(id.clone());
+                        }
+                    }
+                    list_copy
+                },
+                None => SystemPermissionIDList::new()
+            };
+            
+            grantee_list.add(permission_id.clone());
+            table.insert(grantee_id.clone(), grantee_list);
+        });
+    }
+
+    /// Updates the time-indexed list of permissions
+    pub fn update_system_permissions_time_list(
+        permission_id: &SystemPermissionID,
+        add: bool
+    ) {
+        SYSTEM_PERMISSIONS_BY_TIME_LIST.with(|permissions_by_time| {
+            let mut list = permissions_by_time.borrow_mut();
+            
+            if add {
+                // Add to the time list
+                list.push(permission_id)
+                    .expect("Failed to add permission to time list");
+            } else {
+                // Remove from the time list - we need to rebuild it without the removed item
+                let mut new_list = StableVec::init(
+                    MEMORY_MANAGER.with(|m| m.borrow().get(SYS_PERMISSIONS_BY_TIME_MEMORY_ID))
+                ).expect("Failed to initialize new time list");
+                
+                // Copy all items except the one to remove
+                for i in 0..list.len() {
+                    if let Some(id) = list.get(i) {
+                        if id != *permission_id {
+                            new_list.push(&id)
+                                .expect("Failed to add permission to new time list");
+                        }
+                    }
+                }
+                
+                // Replace the old list with the new one
+                *list = new_list;
+            }
+        });
+    }
+
+
+    /// Gets all permission IDs for a specific resource
+    pub fn get_system_permission_ids_for_resource(
+        resource_id: &SystemResourceID
+    ) -> Option<SystemPermissionIDList> {
+        let mut result = None;
+        
+        SYSTEM_PERMISSIONS_BY_RESOURCE_HASHTABLE.with(|permissions_by_resource| {
+            if let Some(permission_ids) = permissions_by_resource.borrow().get(resource_id) {
+                result = Some(permission_ids.clone());
+            }
+        });
+        
+        result
+    }
+
+    /// Gets all permission IDs from the time-ordered list
+    pub fn get_system_permissions_by_time() -> SystemPermissionIDList {
+        let mut result = SystemPermissionIDList::new();
+        
+        SYSTEM_PERMISSIONS_BY_TIME_LIST.with(|time_list| {
+            let list = time_list.borrow();
+            for i in 0..list.len() {
+                if let Some(id) = list.get(i) {
+                    result.add(id);
+                }
+            }
+        });
+        
+        result
+    }
+
+    /// Gets a system permission by ID
+    pub fn get_system_permission_by_id(
+        permission_id: &SystemPermissionID
+    ) -> Option<SystemPermission> {
+        let mut result = None;
+        
+        SYSTEM_PERMISSIONS_BY_ID_HASHTABLE.with(|permissions| {
+            if let Some(permission) = permissions.borrow().get(permission_id) {
+                result = Some(permission.clone());
+            }
+        });
+        
+        result
+    }
+}

--- a/src/canisters-official-backend/src/core/state/permissions/types.rs
+++ b/src/canisters-official-backend/src/core/state/permissions/types.rs
@@ -1,7 +1,8 @@
 use candid::CandidType;
+use ic_stable_structures::{storable::Bound, Storable};
 // src/core/state/permissions/types.rs
 use serde::{Serialize, Deserialize};
-use std::fmt;
+use std::{borrow::Cow, fmt};
 use std::collections::HashSet;
 use serde_diff::{SerdeDiff};
 
@@ -13,6 +14,25 @@ use crate::{core::{
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub struct DirectoryPermissionID(pub String);
+
+impl Storable for DirectoryPermissionID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize DirectoryPermissionID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize DirectoryPermissionID")
+    }
+}
 
 impl fmt::Display for DirectoryPermissionID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -53,12 +73,30 @@ impl fmt::Display for DirectoryPermissionType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub enum PermissionGranteeID {
     Public,
     User(UserID),
     Group(GroupID),
     PlaceholderDirectoryPermissionGrantee(PlaceholderPermissionGranteeID),
+}
+impl Storable for PermissionGranteeID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize PermissionGranteeID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize PermissionGranteeID")
+    }
 }
 impl fmt::Display for PermissionGranteeID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -73,7 +111,7 @@ impl fmt::Display for PermissionGranteeID {
 pub const PUBLIC_GRANTEE_ID: &str = "PUBLIC";
 
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd, PartialEq, Eq)]
 pub struct DirectoryPermission {
     pub id: DirectoryPermissionID,
     pub resource_id: DirectoryResourceID,
@@ -93,6 +131,25 @@ pub struct DirectoryPermission {
     pub labels: Vec<LabelStringValue>,
     pub external_id: Option<ExternalID>,
     pub external_payload: Option<ExternalPayload>,
+}
+
+impl Storable for DirectoryPermission {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize DirectoryPermission");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize DirectoryPermission")
+    }
 }
 
 impl DirectoryPermission {
@@ -222,6 +279,25 @@ impl DirectoryPermission {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, PartialOrd, Ord)]
 pub struct SystemPermissionID(pub String);
 
+impl Storable for SystemPermissionID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize SystemPermissionID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize SystemPermissionID")
+    }
+}
+
 impl fmt::Display for SystemPermissionID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
@@ -238,14 +314,14 @@ pub enum SystemPermissionType {
     Invite,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, PartialOrd, Ord)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SystemTableEnum {
     Drives,
     Disks,
     Contacts,
     Groups,
-    Api_Keys,
+    ApiKeys,
     Permissions,
     Webhooks,
     Labels,
@@ -259,7 +335,7 @@ impl fmt::Display for SystemTableEnum {
             SystemTableEnum::Disks => write!(f, "DISKS"),
             SystemTableEnum::Contacts => write!(f, "CONTACTS"),
             SystemTableEnum::Groups => write!(f, "GROUPS"),
-            SystemTableEnum::Api_Keys => write!(f, "API_KEYS"),
+            SystemTableEnum::ApiKeys => write!(f, "API_KEYS"),
             SystemTableEnum::Permissions => write!(f, "PERMISSIONS"), // special enum, there is no record based permission permission, only a system wide permission that can edit all permissions
             SystemTableEnum::Webhooks => write!(f, "WEBHOOKS"),
             SystemTableEnum::Labels => write!(f, "LABELS"),
@@ -268,7 +344,7 @@ impl fmt::Display for SystemTableEnum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, PartialOrd, Ord)]
 pub enum SystemRecordIDEnum {
     Drive(String),        // DriveID_xxx
     Disk(String),         // DiskID_xxx
@@ -279,6 +355,25 @@ pub enum SystemRecordIDEnum {
     Webhook(String),      // WebhookID_xxx
     Label(String),          // LabelID_xxx
     Unknown(String), // General catch
+}
+
+impl Storable for SystemRecordIDEnum {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize SystemRecordIDEnum");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize SystemRecordIDEnum")
+    }
 }
 
 impl fmt::Display for SystemRecordIDEnum {
@@ -297,10 +392,28 @@ impl fmt::Display for SystemRecordIDEnum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub enum SystemResourceID {
     Table(SystemTableEnum),
     Record(SystemRecordIDEnum), // Stores the full ID like "DiskID_123"
+}
+impl Storable for SystemResourceID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize SystemResourceID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize SystemResourceID")
+    }
 }
 
 impl fmt::Display for SystemResourceID {
@@ -330,6 +443,25 @@ pub struct SystemPermission {
     pub metadata: Option<PermissionMetadata>,
     pub external_id: Option<ExternalID>,
     pub external_payload: Option<ExternalPayload>,
+}
+
+impl Storable for SystemPermission {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize SystemPermission");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize SystemPermission")
+    }
 }
 
 impl SystemPermission {
@@ -496,7 +628,7 @@ impl SystemPermission {
 }
 
 // LabelStringValuePrefix definition
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub struct LabelStringValuePrefix(pub String);
 
 impl fmt::Display for LabelStringValuePrefix {
@@ -506,14 +638,14 @@ impl fmt::Display for LabelStringValuePrefix {
 }
 
 // The main metadata container
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd, PartialEq, Eq, Hash)]
 pub struct PermissionMetadata {
     pub metadata_type: PermissionMetadataTypeEnum, // Using existing enum but not assuming table connection
     pub content: PermissionMetadataContent,
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PermissionMetadataTypeEnum {
     Labels,
@@ -531,9 +663,157 @@ impl fmt::Display for PermissionMetadataTypeEnum {
 
 
 // Define an enum for different types of metadata
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd, PartialEq, Eq, Hash)]
 pub enum PermissionMetadataContent {
     Labels(LabelStringValuePrefix),
     DirectoryPassword(String),
     // Future types can be added here without breaking changes
 }
+
+#[derive(Clone, Debug, CandidType, Deserialize, Serialize, SerdeDiff)]
+pub struct DirectoryPermissionIDList {
+    pub permissions: Vec<DirectoryPermissionID>,
+}
+
+impl Default for DirectoryPermissionIDList {
+    fn default() -> Self {
+        Self { permissions: Vec::new() }
+    }
+}
+
+impl DirectoryPermissionIDList {
+    pub fn new() -> Self {
+        Self { permissions: Vec::new() }
+    }
+    
+    pub fn with_permission(permission_id: DirectoryPermissionID) -> Self {
+        Self { permissions: vec![permission_id] }
+    }
+    
+    pub fn add(&mut self, permission_id: DirectoryPermissionID) {
+        self.permissions.push(permission_id);
+    }
+    
+    pub fn remove(&mut self, permission_id: &DirectoryPermissionID) -> bool {
+        if let Some(pos) = self.permissions.iter().position(|k| k == permission_id) {
+            self.permissions.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+    
+    pub fn iter(&self) -> impl Iterator<Item = &DirectoryPermissionID> {
+        self.permissions.iter()
+    }
+    
+    pub fn is_empty(&self) -> bool {
+        self.permissions.is_empty()
+    }
+}
+
+// From<Vec<DirectoryPermissionID>> for DirectoryPermissionIDList
+impl From<Vec<DirectoryPermissionID>> for DirectoryPermissionIDList {
+    fn from(permissions: Vec<DirectoryPermissionID>) -> Self {
+        Self { permissions }
+    }
+}
+
+// From<DirectoryPermissionIDList> for Vec<DirectoryPermissionID>
+impl From<DirectoryPermissionIDList> for Vec<DirectoryPermissionID> {
+    fn from(list: DirectoryPermissionIDList) -> Self {
+        list.permissions
+    }
+}
+
+
+impl Storable for DirectoryPermissionIDList {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 1024 * 4, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = candid::encode_one(self).unwrap();
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).unwrap()
+    }
+}
+
+// Same for SystemPermissionIDList
+#[derive(Clone, Debug, CandidType, Deserialize, Serialize, SerdeDiff)]
+pub struct SystemPermissionIDList {
+    pub permissions: Vec<SystemPermissionID>,
+}
+
+impl SystemPermissionIDList {
+    pub fn new() -> Self {
+        Self { permissions: Vec::new() }
+    }
+    
+    pub fn with_permission(permission_id: SystemPermissionID) -> Self {
+        Self { permissions: vec![permission_id] }
+    }
+    
+    pub fn add(&mut self, permission_id: SystemPermissionID) {
+        self.permissions.push(permission_id);
+    }
+    
+    pub fn remove(&mut self, permission_id: &SystemPermissionID) -> bool {
+        if let Some(pos) = self.permissions.iter().position(|k| k == permission_id) {
+            self.permissions.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+    
+    pub fn iter(&self) -> impl Iterator<Item = &SystemPermissionID> {
+        self.permissions.iter()
+    }
+    
+    pub fn is_empty(&self) -> bool {
+        self.permissions.is_empty()
+    }
+}
+
+// From<Vec<SystemPermissionID>> for SystemPermissionIDList
+impl From<Vec<SystemPermissionID>> for SystemPermissionIDList {
+    fn from(permissions: Vec<SystemPermissionID>) -> Self {
+        Self { permissions }
+    }
+}
+
+// From<SystemPermissionIDList> for Vec<SystemPermissionID>
+impl From<SystemPermissionIDList> for Vec<SystemPermissionID> {
+    fn from(list: SystemPermissionIDList) -> Self {
+        list.permissions
+    }
+}
+
+// default empty vec
+impl Default for SystemPermissionIDList {
+    fn default() -> Self {
+        Self { permissions: Vec::new() }
+    }
+}
+
+impl Storable for SystemPermissionIDList {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 1024 * 4, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = candid::encode_one(self).unwrap();
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).unwrap()
+    }
+}
+

--- a/src/canisters-official-backend/src/core/state/permissions/types.rs
+++ b/src/canisters-official-backend/src/core/state/permissions/types.rs
@@ -1,3 +1,4 @@
+use candid::CandidType;
 // src/core/state/permissions/types.rs
 use serde::{Serialize, Deserialize};
 use std::fmt;
@@ -10,7 +11,7 @@ use crate::{core::{
     }, types::{IDPrefix, UserID}
 }, rest::{directory::types::DirectoryResourceID, permissions::types::{DirectoryPermissionFE, SystemPermissionFE}}};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct DirectoryPermissionID(pub String);
 
 impl fmt::Display for DirectoryPermissionID {
@@ -19,7 +20,7 @@ impl fmt::Display for DirectoryPermissionID {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct PlaceholderPermissionGranteeID(pub String);
 
 impl fmt::Display for PlaceholderPermissionGranteeID {
@@ -28,7 +29,7 @@ impl fmt::Display for PlaceholderPermissionGranteeID {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum DirectoryPermissionType {
     View,
@@ -52,7 +53,7 @@ impl fmt::Display for DirectoryPermissionType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub enum PermissionGranteeID {
     Public,
     User(UserID),
@@ -72,7 +73,7 @@ impl fmt::Display for PermissionGranteeID {
 pub const PUBLIC_GRANTEE_ID: &str = "PUBLIC";
 
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct DirectoryPermission {
     pub id: DirectoryPermissionID,
     pub resource_id: DirectoryResourceID,
@@ -218,7 +219,7 @@ impl DirectoryPermission {
 
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct SystemPermissionID(pub String);
 
 impl fmt::Display for SystemPermissionID {
@@ -227,7 +228,7 @@ impl fmt::Display for SystemPermissionID {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SystemPermissionType {
     Create,
@@ -237,7 +238,7 @@ pub enum SystemPermissionType {
     Invite,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SystemTableEnum {
     Drives,
@@ -267,7 +268,7 @@ impl fmt::Display for SystemTableEnum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub enum SystemRecordIDEnum {
     Drive(String),        // DriveID_xxx
     Disk(String),         // DiskID_xxx
@@ -296,7 +297,7 @@ impl fmt::Display for SystemRecordIDEnum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub enum SystemResourceID {
     Table(SystemTableEnum),
     Record(SystemRecordIDEnum), // Stores the full ID like "DiskID_123"
@@ -311,7 +312,7 @@ impl fmt::Display for SystemResourceID {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct SystemPermission {
     pub id: SystemPermissionID,
     pub resource_id: SystemResourceID,
@@ -495,7 +496,7 @@ impl SystemPermission {
 }
 
 // LabelStringValuePrefix definition
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct LabelStringValuePrefix(pub String);
 
 impl fmt::Display for LabelStringValuePrefix {
@@ -505,14 +506,14 @@ impl fmt::Display for LabelStringValuePrefix {
 }
 
 // The main metadata container
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct PermissionMetadata {
     pub metadata_type: PermissionMetadataTypeEnum, // Using existing enum but not assuming table connection
     pub content: PermissionMetadataContent,
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PermissionMetadataTypeEnum {
     Labels,
@@ -530,7 +531,7 @@ impl fmt::Display for PermissionMetadataTypeEnum {
 
 
 // Define an enum for different types of metadata
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub enum PermissionMetadataContent {
     Labels(LabelStringValuePrefix),
     DirectoryPassword(String),

--- a/src/canisters-official-backend/src/core/state/permissions/types.rs
+++ b/src/canisters-official-backend/src/core/state/permissions/types.rs
@@ -11,7 +11,7 @@ use crate::{core::{
     }, types::{IDPrefix, UserID}
 }, rest::{directory::types::DirectoryResourceID, permissions::types::{DirectoryPermissionFE, SystemPermissionFE}}};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub struct DirectoryPermissionID(pub String);
 
 impl fmt::Display for DirectoryPermissionID {
@@ -20,7 +20,7 @@ impl fmt::Display for DirectoryPermissionID {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub struct PlaceholderPermissionGranteeID(pub String);
 
 impl fmt::Display for PlaceholderPermissionGranteeID {
@@ -29,7 +29,7 @@ impl fmt::Display for PlaceholderPermissionGranteeID {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum DirectoryPermissionType {
     View,
@@ -219,7 +219,7 @@ impl DirectoryPermission {
 
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, PartialOrd, Ord)]
 pub struct SystemPermissionID(pub String);
 
 impl fmt::Display for SystemPermissionID {
@@ -228,7 +228,7 @@ impl fmt::Display for SystemPermissionID {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, PartialOrd, Ord)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SystemPermissionType {
     Create,

--- a/src/canisters-official-backend/src/core/state/raw_storage/state.rs
+++ b/src/canisters-official-backend/src/core/state/raw_storage/state.rs
@@ -7,7 +7,7 @@ use ic_stable_structures::{
 use std::borrow::Cow;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
-use crate::core::state::raw_storage::types::{ChunkId, FileChunk};
+use crate::{core::state::raw_storage::types::{ChunkId, FileChunk}, MEMORY_MANAGER};
 
 use super::types::{ChunkIdList, CHUNK_SIZE};
 
@@ -55,9 +55,6 @@ impl Storable for FileChunk {
 }
 
 thread_local! {
-    pub(crate) static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = 
-        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
-
     pub(crate) static CHUNKS: RefCell<StableBTreeMap<ChunkId, FileChunk, Memory>> = RefCell::new(
         StableBTreeMap::init(
             MEMORY_MANAGER.with(|m| m.borrow().get(CHUNKS_MEMORY_ID))

--- a/src/canisters-official-backend/src/core/state/raw_storage/state.rs
+++ b/src/canisters-official-backend/src/core/state/raw_storage/state.rs
@@ -14,9 +14,9 @@ use super::types::{ChunkIdList, CHUNK_SIZE};
 type Memory = VirtualMemory<DefaultMemoryImpl>;
 
 // Define memory IDs for different storage types
-const CHUNKS_MEMORY_ID: MemoryId = MemoryId::new(0);
-const FILE_CHUNKS_MEMORY_ID: MemoryId = MemoryId::new(1);
-const FILE_META_MEMORY_ID: MemoryId = MemoryId::new(2);
+const CHUNKS_MEMORY_ID: MemoryId = MemoryId::new(1);
+const FILE_CHUNKS_MEMORY_ID: MemoryId = MemoryId::new(2);
+const FILE_META_MEMORY_ID: MemoryId = MemoryId::new(3);
 
 // Implement Storable for our types
 impl Storable for ChunkId {

--- a/src/canisters-official-backend/src/core/state/raw_storage/types.rs
+++ b/src/canisters-official-backend/src/core/state/raw_storage/types.rs
@@ -1,3 +1,4 @@
+use candid::CandidType;
 use ic_stable_structures::{storable::Bound, Storable};
 // src/core/state/raw_storage/types.rs
 use serde::{Deserialize, Serialize};
@@ -5,7 +6,7 @@ use serde_diff::SerdeDiff;
 use std::{borrow::Cow, fmt};
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord, CandidType)]
 pub struct ChunkId(pub String);
 
 impl fmt::Display for ChunkId {
@@ -14,7 +15,7 @@ impl fmt::Display for ChunkId {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct FileChunk {
     pub id: ChunkId,
     pub file_id: String,
@@ -25,7 +26,7 @@ pub struct FileChunk {
 
 pub const CHUNK_SIZE: usize = 3 * 1024 * (1024 / 2); // 1.5MB chunks
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct ChunkIdList(pub Vec<ChunkId>);
 
 impl Storable for ChunkIdList {
@@ -47,7 +48,7 @@ impl Storable for ChunkIdList {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, SerdeDiff)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, SerdeDiff, CandidType)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum UploadStatus {
     Queued,     // File is created but no chunks uploaded yet

--- a/src/canisters-official-backend/src/core/state/search/state.rs
+++ b/src/canisters-official-backend/src/core/state/search/state.rs
@@ -50,12 +50,21 @@ pub mod state {
             
             // Update the Drive record to store the last_indexed_ms value
             DRIVE_ID.with(|drive_id| {
+                let drive_id_val = drive_id.clone(); // a copy of the key
                 DRIVES_BY_ID_HASHTABLE.with(|drives| {
-                    if let Some(drive) = drives.borrow_mut().get_mut(drive_id) {
+                    let mut map_ref = drives.borrow_mut();
+                    
+                    // Fetch a Drive (clone) from the stable map:
+                    if let Some(mut drive) = map_ref.get(&drive_id_val) {
+                        // Update the Drive in regular memory
                         drive.last_indexed_ms = Some(current_time_ms);
+            
+                        // Reinsert into the stable map
+                        map_ref.insert(drive_id_val, drive);
                     }
                 });
             });
+
         }
         
         result

--- a/src/canisters-official-backend/src/core/state/webhooks/state.rs
+++ b/src/canisters-official-backend/src/core/state/webhooks/state.rs
@@ -3,15 +3,38 @@ pub mod state {
     use std::cell::RefCell;
     use std::collections::HashMap;
 
-    use crate::core::state::webhooks::types::{Webhook, WebhookAltIndexID, WebhookID};
+    use ic_stable_structures::{memory_manager::MemoryId, StableBTreeMap, StableVec, DefaultMemoryImpl};
+
+    use crate::{core::state::webhooks::types::{Webhook, WebhookAltIndexID, WebhookID, WebhookIDList}, MEMORY_MANAGER};
+
+    type Memory = ic_stable_structures::memory_manager::VirtualMemory<DefaultMemoryImpl>;
+    
+    // Define memory IDs for each stable structure
+    pub const WEBHOOKS_BY_ALT_INDEX_MEMORY_ID: MemoryId = MemoryId::new(37);
+    pub const WEBHOOKS_BY_ID_MEMORY_ID: MemoryId = MemoryId::new(38);
+    pub const WEBHOOKS_BY_TIME_MEMORY_ID: MemoryId = MemoryId::new(39);
     
     thread_local! {
-        // users pass in api key value, we O(1) lookup the api key id + O(1) lookup the api key
-        pub(crate) static WEBHOOKS_BY_ALT_INDEX_HASHTABLE: RefCell<HashMap<WebhookAltIndexID, Vec<WebhookID>>> = RefCell::new(HashMap::new());
-        // default is to use the api key id to lookup the api key
-        pub(crate) static WEBHOOKS_BY_ID_HASHTABLE: RefCell<HashMap<WebhookID, Webhook>> = RefCell::new(HashMap::new());
-        // track in hashtable users list of ApiKeyIDs
-        pub(crate) static WEBHOOKS_BY_TIME_LIST: RefCell<Vec<WebhookID>> = RefCell::new(Vec::new());
+        // Convert HashMap<WebhookAltIndexID, Vec<WebhookID>> to StableBTreeMap<WebhookAltIndexID, WebhookIDList>
+        pub(crate) static WEBHOOKS_BY_ALT_INDEX_HASHTABLE: RefCell<StableBTreeMap<WebhookAltIndexID, WebhookIDList, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(WEBHOOKS_BY_ALT_INDEX_MEMORY_ID))
+            )
+        );
+        
+        // Convert HashMap<WebhookID, Webhook> to StableBTreeMap<WebhookID, Webhook>
+        pub(crate) static WEBHOOKS_BY_ID_HASHTABLE: RefCell<StableBTreeMap<WebhookID, Webhook, Memory>> = RefCell::new(
+            StableBTreeMap::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(WEBHOOKS_BY_ID_MEMORY_ID))
+            )
+        );
+        
+        // Convert Vec<WebhookID> to StableVec<WebhookID>
+        pub(crate) static WEBHOOKS_BY_TIME_LIST: RefCell<StableVec<WebhookID, Memory>> = RefCell::new(
+            StableVec::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(WEBHOOKS_BY_TIME_MEMORY_ID))
+            ).expect("Failed to initialize WEBHOOKS_BY_TIME_LIST")
+        );
     }
 
 }

--- a/src/canisters-official-backend/src/core/state/webhooks/types.rs
+++ b/src/canisters-official-backend/src/core/state/webhooks/types.rs
@@ -1,6 +1,7 @@
 // src/core/state/webhooks/types.rs
-use std::fmt;
+use std::{borrow::Cow, fmt};
 use candid::CandidType;
+use ic_stable_structures::{storable::Bound, Storable};
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
 use crate::{core::{api::permissions::system::check_system_permissions, state::{directory::types::{FileID, FolderID}, drives::{state::state::OWNER_ID, types::{ExternalID, ExternalPayload}}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}, labels::types::{redact_label, LabelStringValue}}, types::{IDPrefix, UserID}}, rest::webhooks::types::WebhookFE};
@@ -22,6 +23,22 @@ pub struct Webhook {
     pub external_id: Option<ExternalID>,
     pub external_payload: Option<ExternalPayload>,
     pub created_at: u64,
+}
+
+impl Storable for Webhook {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = candid::encode_one(self).unwrap();
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).unwrap()
+    }
 }
 
 impl Webhook {
@@ -56,7 +73,7 @@ impl Webhook {
 
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub struct WebhookID(pub String);
 impl fmt::Display for WebhookID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -64,14 +81,46 @@ impl fmt::Display for WebhookID {
     }
 }
 
+impl Storable for WebhookID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = candid::encode_one(self).unwrap();
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).unwrap()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub struct WebhookAltIndexID(pub String);
 impl fmt::Display for WebhookAltIndexID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
+
+impl Storable for WebhookAltIndexID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = candid::encode_one(self).unwrap();
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).unwrap()
+    }
+}
+
 
 impl WebhookAltIndexID {
     pub const ALL_FILES: &'static str = "ALL_FILES";
@@ -253,5 +302,88 @@ impl ToString for WebhookEventLabel {
             Self::OrganizationSuperswapUser => "organization.superswap_user",
             Self::OrganizationInboxNewNotif => "organization.inbox.new_mail",
         }.to_string()
+    }
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize, Serialize, SerdeDiff)]
+pub struct WebhookIDList {
+    pub webhooks: Vec<WebhookID>,
+}
+
+impl WebhookIDList {
+    pub fn new() -> Self {
+        Self { webhooks: Vec::new() }
+    }
+    
+    pub fn with_webhook(webhook_id: WebhookID) -> Self {
+        Self { webhooks: vec![webhook_id] }
+    }
+    
+    pub fn add(&mut self, webhook_id: WebhookID) {
+        self.webhooks.push(webhook_id);
+    }
+    
+    pub fn remove(&mut self, webhook_id: &WebhookID) -> bool {
+        if let Some(pos) = self.webhooks.iter().position(|w| w == webhook_id) {
+            self.webhooks.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+    
+    pub fn iter(&self) -> impl Iterator<Item = &WebhookID> {
+        self.webhooks.iter()
+    }
+    
+    pub fn is_empty(&self) -> bool {
+        self.webhooks.is_empty()
+    }
+    
+    pub fn contains(&self, webhook_id: &WebhookID) -> bool {
+        self.webhooks.contains(webhook_id)
+    }
+    
+    pub fn len(&self) -> usize {
+        self.webhooks.len()
+    }
+    
+    pub fn get(&self, index: usize) -> Option<&WebhookID> {
+        self.webhooks.get(index)
+    }
+}
+
+// Implement conversion between Vec<WebhookID> and WebhookIDList
+impl From<Vec<WebhookID>> for WebhookIDList {
+    fn from(webhooks: Vec<WebhookID>) -> Self {
+        Self { webhooks }
+    }
+}
+
+impl From<WebhookIDList> for Vec<WebhookID> {
+    fn from(list: WebhookIDList) -> Self {
+        list.webhooks
+    }
+}
+
+// Implement Storable for WebhookIDList
+impl Storable for WebhookIDList {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256 * 1024 * 4, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = candid::encode_one(self).unwrap();
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        candid::decode_one(&bytes).unwrap()
+    }
+}
+impl Default for WebhookIDList {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/canisters-official-backend/src/core/state/webhooks/types.rs
+++ b/src/canisters-official-backend/src/core/state/webhooks/types.rs
@@ -1,12 +1,13 @@
 // src/core/state/webhooks/types.rs
 use std::fmt;
+use candid::CandidType;
 use serde::{Serialize, Deserialize};
 use serde_diff::{SerdeDiff};
 use crate::{core::{api::permissions::system::check_system_permissions, state::{directory::types::{FileID, FolderID}, drives::{state::state::OWNER_ID, types::{ExternalID, ExternalPayload}}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}, labels::types::{redact_label, LabelStringValue}}, types::{IDPrefix, UserID}}, rest::webhooks::types::WebhookFE};
 
 
 
-#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct Webhook {
     pub id: WebhookID,
     pub name: String,
@@ -55,7 +56,7 @@ impl Webhook {
 
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct WebhookID(pub String);
 impl fmt::Display for WebhookID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -64,7 +65,7 @@ impl fmt::Display for WebhookID {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct WebhookAltIndexID(pub String);
 impl fmt::Display for WebhookAltIndexID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -112,7 +113,7 @@ impl WebhookAltIndexID {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, SerdeDiff, CandidType)]
 #[serde(rename_all = "snake_case")]
 pub enum WebhookEventLabel {
     #[serde(rename = "file.viewed")]

--- a/src/canisters-official-backend/src/core/types.rs
+++ b/src/canisters-official-backend/src/core/types.rs
@@ -1,10 +1,11 @@
 
 // src/core/state/types.rs
 use std::fmt;
+use candid::CandidType;
 use serde::{Deserialize, Serialize};
 use serde_diff::{Diff, SerdeDiff};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType   )]
 pub struct PublicKeyICP(pub String);
 
 impl fmt::Display for PublicKeyICP {
@@ -14,7 +15,7 @@ impl fmt::Display for PublicKeyICP {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct ICPPrincipalString(pub PublicKeyICP);
 
 impl fmt::Display for ICPPrincipalString {
@@ -24,7 +25,7 @@ impl fmt::Display for ICPPrincipalString {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct PublicKeyEVM(pub String);
 
 impl fmt::Display for PublicKeyEVM {
@@ -34,7 +35,7 @@ impl fmt::Display for PublicKeyEVM {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct ClientSuggestedUUID(pub String);
 
 impl fmt::Display for ClientSuggestedUUID {
@@ -43,7 +44,7 @@ impl fmt::Display for ClientSuggestedUUID {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct UserID(pub String);
 
 impl fmt::Display for UserID {
@@ -64,7 +65,7 @@ impl UserID {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub enum IDPrefix {
     File,
     Folder,
@@ -115,7 +116,7 @@ impl IDPrefix {
 
 
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub enum AuthPrefixEnum {
     ApiKey,
     Signature,
@@ -129,7 +130,7 @@ impl AuthPrefixEnum {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct ParsedAuth {
     pub auth_type: AuthPrefixEnum,
     pub value: String,

--- a/src/canisters-official-backend/src/core/types.rs
+++ b/src/canisters-official-backend/src/core/types.rs
@@ -15,6 +15,26 @@ impl fmt::Display for PublicKeyICP {
     }
 }
 
+impl Storable for PublicKeyICP {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize PublicKeyICP");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize PublicKeyICP")
+    }
+}
+
+
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub struct ICPPrincipalString(pub PublicKeyICP);

--- a/src/canisters-official-backend/src/core/types.rs
+++ b/src/canisters-official-backend/src/core/types.rs
@@ -1,7 +1,8 @@
 
 // src/core/state/types.rs
-use std::fmt;
+use std::{borrow::Cow, fmt};
 use candid::CandidType;
+use ic_stable_structures::{storable::Bound, Storable};
 use serde::{Deserialize, Serialize};
 use serde_diff::{Diff, SerdeDiff};
 
@@ -44,8 +45,28 @@ impl fmt::Display for ClientSuggestedUUID {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub struct UserID(pub String);
+
+
+impl Storable for UserID {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize UserID");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize UserID")
+    }
+}
 
 impl fmt::Display for UserID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/canisters-official-backend/src/core/types.rs
+++ b/src/canisters-official-backend/src/core/types.rs
@@ -6,7 +6,7 @@ use ic_stable_structures::{storable::Bound, Storable};
 use serde::{Deserialize, Serialize};
 use serde_diff::{Diff, SerdeDiff};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType   )]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub struct PublicKeyICP(pub String);
 
 impl fmt::Display for PublicKeyICP {
@@ -16,7 +16,7 @@ impl fmt::Display for PublicKeyICP {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType, Ord, PartialOrd)]
 pub struct ICPPrincipalString(pub PublicKeyICP);
 
 impl fmt::Display for ICPPrincipalString {
@@ -24,6 +24,26 @@ impl fmt::Display for ICPPrincipalString {
         write!(f, "{}", self.0)
     }
 }
+
+impl Storable for ICPPrincipalString {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 256, // Adjust based on your needs
+        is_fixed_size: false,
+    };
+    
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .expect("Failed to serialize ICPPrincipalString");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        ciborium::de::from_reader(bytes.as_ref())
+            .expect("Failed to deserialize ICPPrincipalString")
+    }
+}
+
 
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]

--- a/src/canisters-official-backend/src/lib.rs
+++ b/src/canisters-official-backend/src/lib.rs
@@ -1,18 +1,24 @@
 // src/lib.rs
-use ic_cdk::{api::stable::{StableReader, StableWriter}, *};
+use ic_cdk::*;
 use ic_http_certification::{HttpRequest, HttpResponse, StatusCode};
-use core::{api::{replay::diff::{apply_entire_state, snapshot_entire_state, EntireState}, uuid::format_user_id}, state::{api_keys::state::state::init_default_admin_apikey, contacts::state::state::init_default_owner_contact, disks::state::state::init_default_disks, drives::state::state::init_self_drive, groups::state::state::init_default_group}, types::UserID};
-use std::{borrow::Cow, cell::{RefCell}, collections::HashMap};
+use core::{api::uuid::format_user_id, state::{api_keys::state::state::init_default_admin_apikey, contacts::state::state::init_default_owner_contact, disks::state::state::init_default_disks, drives::state::state::init_self_drive, groups::state::state::init_default_group}, types::UserID};
+use std::{cell::RefCell, collections::HashMap};
 use serde::{Deserialize, Serialize};
 use bip39::{Mnemonic, Language};
 mod logger;
 mod rest;
 mod core;
 use rest::{router, types::validate_icp_principal};
-use candid::{encode_one, CandidType, Decode, Encode};
-use ic_stable_structures::{Cell, memory_manager::{MemoryId, MemoryManager, VirtualMemory}, DefaultMemoryImpl, Storable};
+use candid::{CandidType, Decode, Encode};
 
 
+
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::{DefaultMemoryImpl, StableCell, Storable}; // Import Storable
+
+type Memory = VirtualMemory<DefaultMemoryImpl>;
+
+const INITIALIZED_FLAG_MEMORY_ID: MemoryId = MemoryId::new(0);
 
 // change this to false for production
 pub static LOCAL_DEV_MODE: bool = true;
@@ -27,54 +33,32 @@ pub struct InitArgs {
     pub spawn_redeem_code: Option<String>,
 }
 
-
-// Define the types we need
-type Memory = ic_stable_structures::memory_manager::VirtualMemory<DefaultMemoryImpl>;
-
-// Define stable memory cells for state management
+// Track if we've already initialized to prevent double initialization
 thread_local! {
-    // Memory manager for stable storage
-    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = 
+
+    // The memory manager is used for simulating multiple memories.
+    pub(crate) static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
-    
-    // Cell for tracking if canister is initialized
-    static INITIALIZED: RefCell<Cell<bool, Memory>> = RefCell::new(
-        Cell::init(
-            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0))),
-            false
-        ).unwrap()
-    );
-    
-    // Cell for storing the serialized state size
-    static STATE_SIZE: RefCell<Cell<u64, Memory>> = RefCell::new(
-        Cell::init(
-            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(1))),
-            0
-        ).unwrap()
-    );
-    
-    // We'll use a region of memory starting at ID 2 for the actual state data
-    static STATE_MEMORY: RefCell<Memory> = RefCell::new(
-        MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(2)))
-    );
-}
 
-/// Query function to check if the canister has been initialized
-#[query]
-fn is_initialized() -> bool {
-    let _is_initialized = INITIALIZED.with(|cell| cell.borrow().get().clone());
-    debug_log!("is_initialized: {}", _is_initialized);
-    _is_initialized
-}
+    // Stable Cell for the INITIALIZED flag. Uses MemoryId(0).
+    // We store a u8: 0 = false, 1 = true, as bool support might vary or have quirks.
+    // Alternatively, you could create a custom struct/enum that implements Storable.
+    // Using `bool` directly *should* work if it implements Storable (which it does via candid).
+    // Let's try with bool first for clarity, but u8 is a safe fallback.
+    static INITIALIZED_FLAG: RefCell<StableCell<bool, Memory>> = RefCell::new(
+        StableCell::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(INITIALIZED_FLAG_MEMORY_ID)),
+            false // Default value if the cell is newly created (e.g., first deployment)
+        ).expect("Failed to initialize StableCell for INITIALIZED_FLAG")
+    );
 
-/// Update function to set the initialized flag to true
-#[update]
-fn set_initialized() -> bool {
-    INITIALIZED.with(|cell| {
-        let was_initialized = cell.borrow().get().clone();
-        cell.borrow_mut().set(true).unwrap();
-        was_initialized
-    })
+    // --- Other State (potentially also using stable structures) ---
+    // Example: If you were to move other state to stable structures
+    // static CONTACTS: RefCell<StableBTreeMap<UserID, Contact, Memory>> = RefCell::new(
+    //     StableBTreeMap::init(
+    //         MEMORY_MANAGER.with(|m| m.borrow().get(CONTACTS_MEMORY_ID)),
+    //     )
+    // );
 }
 
 
@@ -84,20 +68,29 @@ fn init() {
     let args = ic_cdk::api::call::arg_data::<(Option<InitArgs>,)>(ic_cdk::api::call::ArgDecoderConfig::default()).0;
     debug_log!("INIT FUNCTION - Args extracted, calling initialize_canister...");
     initialize_canister(args);
+
+
+    debug_log!("Initializing routes...");
+    router::init_routes();
+    
     debug_log!("INIT FUNCTION COMPLETED");
 }
 
 
 fn initialize_canister(args: Option<InitArgs>) {
+
+
+    debug_log!("Initializing canister...");
     // Check if we've already initialized to prevent re-initialization
-    if is_initialized() {
+    let already_initialized = INITIALIZED_FLAG.with(|flag_cell| {
+        *flag_cell.borrow().get() // Get the value from the stable cell
+    });
+
+    if already_initialized {
         debug_log!("Canister already initialized, skipping initialization");
         return;
     }
 
-    debug_log!("Initializing canister...");
-    router::init_routes();
-    
     // Process the arguments
     if let Some(init_args) = args {
         // Validate the owner ICP principal
@@ -128,6 +121,14 @@ fn initialize_canister(args: Option<InitArgs>) {
                 init_default_disks();
                 init_default_group();
 
+                // **** SET THE STABLE FLAG TO TRUE ****
+                INITIALIZED_FLAG.with(|flag_cell| {
+                    flag_cell.borrow_mut()
+                        .set(true) // Set the flag to true in stable memory
+                        .expect("Failed to set INITIALIZED_FLAG to true in stable memory");
+                });
+                debug_log!("Initialization successful, stable flag set to true.");
+
             },
             Err(validation_error) => {
                 // Log and trap (abort) on invalid ICP principal
@@ -144,133 +145,27 @@ fn initialize_canister(args: Option<InitArgs>) {
     
 }
 
-#[pre_upgrade]
-fn pre_upgrade() {
-    debug_log!("Starting pre_upgrade - preparing for canister upgrade");
-    
-    // Take a snapshot of the entire state
-    let state_snapshot = snapshot_entire_state();
-    debug_log!("State snapshot taken");
-    
-    // Use direct binary serialization with Candid
-    let encoded_state = match encode_one(state_snapshot) {
-        Ok(bytes) => bytes,
-        Err(e) => {
-            debug_log!("FATAL: Failed to serialize state for upgrade: {}", e);
-            ic_cdk::trap(&format!("Failed to serialize state for upgrade: {}", e));
-        }
-    };
-    
-    let state_size = encoded_state.len() as u64;
-    debug_log!("State serialized, size: {} bytes", state_size);
-    
-    // Write to stable storage
-    let mut writer = StableWriter::default();
-    
-    // First, write the size of the serialized data as 8 bytes
-    match writer.write(&state_size.to_be_bytes()) {
-        Ok(_) => debug_log!("Successfully wrote state size to stable storage"),
-        Err(e) => {
-            debug_log!("FATAL: Failed to write state size to stable storage: {}", e);
-            ic_cdk::trap(&format!("Failed to write state size to stable storage: {}", e));
-        }
-    }
-    
-    // Then, write the actual serialized data
-    match writer.write(&encoded_state) {
-        Ok(_) => debug_log!("Successfully wrote state data to stable storage"),
-        Err(e) => {
-            debug_log!("FATAL: Failed to write state data to stable storage: {}", e);
-            ic_cdk::trap(&format!("Failed to write state data to stable storage: {}", e));
-        }
-    }
-    
-    debug_log!("Pre-upgrade serialization completed successfully");
-}
-
 #[post_upgrade]
 fn post_upgrade() {
-    debug_log!("Starting post_upgrade - restoring from upgrade");
+    // No arguments on upgrade, just re-initialize routes
+    debug_log!("Post-upgrade initialization...");
+
     
-    // Create a reader for the stable storage
-    let mut reader = StableReader::default();
-    
-    // First, read the size of the serialized data
-    let mut size_buffer = [0u8; 8]; // 8 bytes for u64
-    
-    match reader.read(&mut size_buffer) {
-        Ok(bytes_read) if bytes_read == 8 => {
-            // Convert bytes to u64 (size of our serialized data)
-            let size = u64::from_be_bytes(size_buffer);
-            debug_log!("Found serialized state of size: {} bytes", size);
-            
-            if size > 0 && size < 4_000_000_000 { // Sanity check on size
-                // Create a buffer of the exact size needed
-                let mut state_buffer = vec![0u8; size as usize];
-                
-                // Read the actual state data
-                match reader.read(&mut state_buffer) {
-                    Ok(bytes_read) if bytes_read as u64 == size => {
-                        debug_log!("Successfully read {} bytes of state data", bytes_read);
-                        
-                        // Deserialize the state using Candid
-                        match Decode!(&state_buffer, EntireState) {
-                            Ok(state) => {
-                                debug_log!("Successfully deserialized state, restoring...");
-                                
-                                // IMPORTANT: Apply the state WITHOUT initializing routes
-                                // This preserves all existing route registrations
-                                apply_entire_state(state);
-                                
-                                // Mark as initialized after successful restoration
-                                set_initialized();
-                                
-                                debug_log!("State successfully restored from upgrade");
-                                return; // Exit early on successful restore
-                            },
-                            Err(e) => {
-                                debug_log!("Error deserializing state from upgrade: {:?}", e);
-                                // Fall through to fresh initialization
-                            }
-                        }
-                    },
-                    Ok(bytes_read) => {
-                        debug_log!("Partial read of state data: expected {} bytes, got {}", 
-                                   size, bytes_read);
-                        // Fall through to fresh initialization
-                    },
-                    Err(e) => {
-                        debug_log!("Error reading state data from stable storage: {:?}", e);
-                        // Fall through to fresh initialization
-                    }
-                }
-            } else {
-                debug_log!("Invalid state size: {}", size);
-                // Fall through to fresh initialization
-            }
-        },
-        Ok(_) => {
-            debug_log!("Failed to read state size header");
-            // Fall through to fresh initialization
-        },
-        Err(e) => {
-            debug_log!("Error reading state size from stable storage: {:?}", e);
-            // Fall through to fresh initialization
-        }
-    }
-    
-    // Only reach here if state restoration failed
-    debug_log!("State restoration failed, falling back to fresh initialization");
-    
-    // For fresh initialization, we DO need to initialize routes
+    debug_log!("Initializing routes...");
     router::init_routes();
     
-    let args = ic_cdk::api::call::arg_data::<(Option<InitArgs>,)>(
-        ic_cdk::api::call::ArgDecoderConfig::default()
-    ).0;
-    initialize_canister(args);
+    // Then check if we need to set up state
+    let already_initialized = INITIALIZED_FLAG.with(|flag_cell| {
+        *flag_cell.borrow().get() // Get the value from the stable cell
+    });
     
-    debug_log!("Post-upgrade completed");
+    if already_initialized {
+        debug_log!("Canister already initialized, skipping full initialization");
+    } else {
+         // Either use arguments from upgrade call or fallback to defaults
+         let args = ic_cdk::api::call::arg_data::<(Option<InitArgs>,)>(ic_cdk::api::call::ArgDecoderConfig::default()).0;
+         initialize_canister(args);
+    }
 }
 
 #[query]

--- a/src/canisters-official-backend/src/lib.rs
+++ b/src/canisters-official-backend/src/lib.rs
@@ -109,11 +109,11 @@ fn initialize_canister(args: Option<InitArgs>) {
 
                 // Verify the values were set correctly
                 crate::core::state::drives::state::state::OWNER_ID.with(|id| {
-                    debug_log!("After init, owner_id is: {}", id.borrow().0);
+                    debug_log!("After init, owner_id is: {}", id.borrow().get().clone());
                 });
                 
                 crate::core::state::drives::state::state::SPAWN_REDEEM_CODE.with(|code| {
-                    debug_log!("After init, spawn_redeem_code is: {}", code.borrow().0);
+                    debug_log!("After init, spawn_redeem_code is: {}", code.borrow().get().clone());
                 });
 
                 init_default_admin_apikey();

--- a/src/canisters-official-backend/src/lib.rs
+++ b/src/canisters-official-backend/src/lib.rs
@@ -1,15 +1,17 @@
 // src/lib.rs
-use ic_cdk::*;
+use ic_cdk::{api::stable::{StableReader, StableWriter}, *};
 use ic_http_certification::{HttpRequest, HttpResponse, StatusCode};
-use core::{api::uuid::format_user_id, state::{api_keys::state::state::init_default_admin_apikey, contacts::state::state::init_default_owner_contact, disks::state::state::init_default_disks, drives::state::state::init_self_drive, groups::state::state::init_default_group}, types::UserID};
-use std::{cell::RefCell, collections::HashMap};
+use core::{api::{replay::diff::{apply_entire_state, snapshot_entire_state, EntireState}, uuid::format_user_id}, state::{api_keys::state::state::init_default_admin_apikey, contacts::state::state::init_default_owner_contact, disks::state::state::init_default_disks, drives::state::state::init_self_drive, groups::state::state::init_default_group}, types::UserID};
+use std::{borrow::Cow, cell::{RefCell}, collections::HashMap};
 use serde::{Deserialize, Serialize};
 use bip39::{Mnemonic, Language};
 mod logger;
 mod rest;
 mod core;
 use rest::{router, types::validate_icp_principal};
-use candid::{CandidType, Decode, Encode};
+use candid::{encode_one, CandidType, Decode, Encode};
+use ic_stable_structures::{Cell, memory_manager::{MemoryId, MemoryManager, VirtualMemory}, DefaultMemoryImpl, Storable};
+
 
 
 // change this to false for production
@@ -25,9 +27,54 @@ pub struct InitArgs {
     pub spawn_redeem_code: Option<String>,
 }
 
-// Track if we've already initialized to prevent double initialization
+
+// Define the types we need
+type Memory = ic_stable_structures::memory_manager::VirtualMemory<DefaultMemoryImpl>;
+
+// Define stable memory cells for state management
 thread_local! {
-    static INITIALIZED: RefCell<bool> = RefCell::new(false);
+    // Memory manager for stable storage
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = 
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+    
+    // Cell for tracking if canister is initialized
+    static INITIALIZED: RefCell<Cell<bool, Memory>> = RefCell::new(
+        Cell::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0))),
+            false
+        ).unwrap()
+    );
+    
+    // Cell for storing the serialized state size
+    static STATE_SIZE: RefCell<Cell<u64, Memory>> = RefCell::new(
+        Cell::init(
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(1))),
+            0
+        ).unwrap()
+    );
+    
+    // We'll use a region of memory starting at ID 2 for the actual state data
+    static STATE_MEMORY: RefCell<Memory> = RefCell::new(
+        MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(2)))
+    );
+}
+
+/// Query function to check if the canister has been initialized
+#[query]
+fn is_initialized() -> bool {
+    let _is_initialized = INITIALIZED.with(|cell| cell.borrow().get().clone());
+    debug_log!("is_initialized: {}", _is_initialized);
+    _is_initialized
+}
+
+/// Update function to set the initialized flag to true
+#[update]
+fn set_initialized() -> bool {
+    INITIALIZED.with(|cell| {
+        let was_initialized = cell.borrow().get().clone();
+        cell.borrow_mut().set(true).unwrap();
+        was_initialized
+    })
 }
 
 
@@ -43,16 +90,7 @@ fn init() {
 
 fn initialize_canister(args: Option<InitArgs>) {
     // Check if we've already initialized to prevent re-initialization
-    let already_initialized = INITIALIZED.with(|initialized| {
-        if *initialized.borrow() {
-            true
-        } else {
-            *initialized.borrow_mut() = true;
-            false
-        }
-    });
-
-    if already_initialized {
+    if is_initialized() {
         debug_log!("Canister already initialized, skipping initialization");
         return;
     }
@@ -89,6 +127,7 @@ fn initialize_canister(args: Option<InitArgs>) {
                 init_default_owner_contact(init_args.owner_name);
                 init_default_disks();
                 init_default_group();
+
             },
             Err(validation_error) => {
                 // Log and trap (abort) on invalid ICP principal
@@ -105,20 +144,133 @@ fn initialize_canister(args: Option<InitArgs>) {
     
 }
 
+#[pre_upgrade]
+fn pre_upgrade() {
+    debug_log!("Starting pre_upgrade - preparing for canister upgrade");
+    
+    // Take a snapshot of the entire state
+    let state_snapshot = snapshot_entire_state();
+    debug_log!("State snapshot taken");
+    
+    // Use direct binary serialization with Candid
+    let encoded_state = match encode_one(state_snapshot) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            debug_log!("FATAL: Failed to serialize state for upgrade: {}", e);
+            ic_cdk::trap(&format!("Failed to serialize state for upgrade: {}", e));
+        }
+    };
+    
+    let state_size = encoded_state.len() as u64;
+    debug_log!("State serialized, size: {} bytes", state_size);
+    
+    // Write to stable storage
+    let mut writer = StableWriter::default();
+    
+    // First, write the size of the serialized data as 8 bytes
+    match writer.write(&state_size.to_be_bytes()) {
+        Ok(_) => debug_log!("Successfully wrote state size to stable storage"),
+        Err(e) => {
+            debug_log!("FATAL: Failed to write state size to stable storage: {}", e);
+            ic_cdk::trap(&format!("Failed to write state size to stable storage: {}", e));
+        }
+    }
+    
+    // Then, write the actual serialized data
+    match writer.write(&encoded_state) {
+        Ok(_) => debug_log!("Successfully wrote state data to stable storage"),
+        Err(e) => {
+            debug_log!("FATAL: Failed to write state data to stable storage: {}", e);
+            ic_cdk::trap(&format!("Failed to write state data to stable storage: {}", e));
+        }
+    }
+    
+    debug_log!("Pre-upgrade serialization completed successfully");
+}
+
 #[post_upgrade]
 fn post_upgrade() {
-    // No arguments on upgrade, just re-initialize routes
-    debug_log!("Post-upgrade initialization...");
-    // Then check if we need to set up state
-    let needs_init = INITIALIZED.with(|initialized| !*initialized.borrow());
+    debug_log!("Starting post_upgrade - restoring from upgrade");
     
-    if needs_init {
-        // Either use arguments from upgrade call or fallback to defaults
-        let args = ic_cdk::api::call::arg_data::<(Option<InitArgs>,)>(ic_cdk::api::call::ArgDecoderConfig::default()).0;
-        initialize_canister(args);
-    } else {
-        debug_log!("Canister already initialized, skipping full initialization");
+    // Create a reader for the stable storage
+    let mut reader = StableReader::default();
+    
+    // First, read the size of the serialized data
+    let mut size_buffer = [0u8; 8]; // 8 bytes for u64
+    
+    match reader.read(&mut size_buffer) {
+        Ok(bytes_read) if bytes_read == 8 => {
+            // Convert bytes to u64 (size of our serialized data)
+            let size = u64::from_be_bytes(size_buffer);
+            debug_log!("Found serialized state of size: {} bytes", size);
+            
+            if size > 0 && size < 4_000_000_000 { // Sanity check on size
+                // Create a buffer of the exact size needed
+                let mut state_buffer = vec![0u8; size as usize];
+                
+                // Read the actual state data
+                match reader.read(&mut state_buffer) {
+                    Ok(bytes_read) if bytes_read as u64 == size => {
+                        debug_log!("Successfully read {} bytes of state data", bytes_read);
+                        
+                        // Deserialize the state using Candid
+                        match Decode!(&state_buffer, EntireState) {
+                            Ok(state) => {
+                                debug_log!("Successfully deserialized state, restoring...");
+                                
+                                // IMPORTANT: Apply the state WITHOUT initializing routes
+                                // This preserves all existing route registrations
+                                apply_entire_state(state);
+                                
+                                // Mark as initialized after successful restoration
+                                set_initialized();
+                                
+                                debug_log!("State successfully restored from upgrade");
+                                return; // Exit early on successful restore
+                            },
+                            Err(e) => {
+                                debug_log!("Error deserializing state from upgrade: {:?}", e);
+                                // Fall through to fresh initialization
+                            }
+                        }
+                    },
+                    Ok(bytes_read) => {
+                        debug_log!("Partial read of state data: expected {} bytes, got {}", 
+                                   size, bytes_read);
+                        // Fall through to fresh initialization
+                    },
+                    Err(e) => {
+                        debug_log!("Error reading state data from stable storage: {:?}", e);
+                        // Fall through to fresh initialization
+                    }
+                }
+            } else {
+                debug_log!("Invalid state size: {}", size);
+                // Fall through to fresh initialization
+            }
+        },
+        Ok(_) => {
+            debug_log!("Failed to read state size header");
+            // Fall through to fresh initialization
+        },
+        Err(e) => {
+            debug_log!("Error reading state size from stable storage: {:?}", e);
+            // Fall through to fresh initialization
+        }
     }
+    
+    // Only reach here if state restoration failed
+    debug_log!("State restoration failed, falling back to fresh initialization");
+    
+    // For fresh initialization, we DO need to initialize routes
+    router::init_routes();
+    
+    let args = ic_cdk::api::call::arg_data::<(Option<InitArgs>,)>(
+        ic_cdk::api::call::ArgDecoderConfig::default()
+    ).0;
+    initialize_canister(args);
+    
+    debug_log!("Post-upgrade completed");
 }
 
 #[query]

--- a/src/canisters-official-backend/src/rest/api_keys/handler.rs
+++ b/src/canisters-official-backend/src/rest/api_keys/handler.rs
@@ -40,7 +40,7 @@ pub mod apikeys_handlers {
         // Check system permissions if not owner or own key
         if !is_owner && !is_own_key {
             let table_permissions = check_system_permissions(
-                SystemResourceID::Table(SystemTableEnum::Api_Keys),
+                SystemResourceID::Table(SystemTableEnum::ApiKeys),
                 PermissionGranteeID::User(requester_api_key.user_id.clone())
             );
             let resource_id = SystemResourceID::Record(SystemRecordIDEnum::ApiKey(requested_id.to_string()));
@@ -100,7 +100,7 @@ pub mod apikeys_handlers {
         let is_own_keys = requester_api_key.user_id == requested_user_id;
 
         if !is_owner && !is_own_keys {
-            let resource_id = SystemResourceID::Table(SystemTableEnum::Api_Keys);
+            let resource_id = SystemResourceID::Table(SystemTableEnum::ApiKeys);
             let permissions = check_system_permissions(
                 resource_id,
                 PermissionGranteeID::User(requester_api_key.user_id.clone())
@@ -171,7 +171,7 @@ pub mod apikeys_handlers {
                     
         // Check system permission to create if not owner
         if !is_owner {
-            let resource_id = SystemResourceID::Table(SystemTableEnum::Api_Keys);
+            let resource_id = SystemResourceID::Table(SystemTableEnum::ApiKeys);
             let permissions = check_system_permissions(
                 resource_id,
                 PermissionGranteeID::User(requester_api_key.user_id.clone())
@@ -305,7 +305,7 @@ pub mod apikeys_handlers {
         // Check system permission to update if not owner or own key
         if !is_owner && !is_own_key {
             let table_permissions = check_system_permissions(
-                SystemResourceID::Table(SystemTableEnum::Api_Keys),
+                SystemResourceID::Table(SystemTableEnum::ApiKeys),
                 PermissionGranteeID::User(requester_api_key.user_id.clone())
             );
             let resource_id = SystemResourceID::Record(SystemRecordIDEnum::ApiKey(api_key.id.to_string()));
@@ -441,7 +441,7 @@ pub mod apikeys_handlers {
 
         if !is_owner && !is_own_key {
             let table_permission = check_system_permissions(
-                SystemResourceID::Table(SystemTableEnum::Api_Keys),
+                SystemResourceID::Table(SystemTableEnum::ApiKeys),
                 PermissionGranteeID::User(requester_api_key.user_id.clone())
             );
             let resource_id = SystemResourceID::Record(SystemRecordIDEnum::ApiKey(api_key.id.to_string()));

--- a/src/canisters-official-backend/src/rest/api_keys/handler.rs
+++ b/src/canisters-official-backend/src/rest/api_keys/handler.rs
@@ -2,7 +2,7 @@
 
 pub mod apikeys_handlers {
     use crate::{
-        core::{api::{permissions::system::check_system_permissions, replay::diff::{snapshot_poststate, snapshot_prestate}, uuid::{generate_api_key, generate_uuidv4, mark_claimed_uuid}}, state::{api_keys::{state::state::{APIKEYS_BY_ID_HASHTABLE, APIKEYS_BY_VALUE_HASHTABLE, USERS_APIKEYS_HASHTABLE}, types::{ApiKey, ApiKeyID, ApiKeyValue}}, drives::{state::state::{update_external_id_mapping, OWNER_ID}, types::{ExternalID, ExternalPayload}}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}}, types::{IDPrefix, PublicKeyICP, UserID}}, debug_log, rest::{api_keys::types::{ApiKeyFE, CreateApiKeyRequestBody, CreateApiKeyResponse, DeleteApiKeyRequestBody, DeleteApiKeyResponse, DeletedApiKeyData, ErrorResponse, GetApiKeyResponse, ListApiKeysResponse, UpdateApiKeyRequestBody, UpdateApiKeyResponse}, auth::{authenticate_request, create_auth_error_response}}, 
+        core::{api::{permissions::system::check_system_permissions, replay::diff::{snapshot_poststate, snapshot_prestate}, uuid::{generate_api_key, generate_uuidv4, mark_claimed_uuid}}, state::{api_keys::{state::state::{APIKEYS_BY_ID_HASHTABLE, APIKEYS_BY_VALUE_HASHTABLE, USERS_APIKEYS_HASHTABLE}, types::{ApiKey, ApiKeyID, ApiKeyIDList, ApiKeyValue}}, drives::{state::state::{update_external_id_mapping, OWNER_ID}, types::{ExternalID, ExternalPayload}}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}}, types::{IDPrefix, PublicKeyICP, UserID}}, debug_log, rest::{api_keys::types::{ApiKeyFE, CreateApiKeyRequestBody, CreateApiKeyResponse, DeleteApiKeyRequestBody, DeleteApiKeyResponse, DeletedApiKeyData, ErrorResponse, GetApiKeyResponse, ListApiKeysResponse, UpdateApiKeyRequestBody, UpdateApiKeyResponse}, auth::{authenticate_request, create_auth_error_response}}, 
     };
     use ic_http_certification::{HttpRequest, HttpResponse, StatusCode};
     use matchit::Params;
@@ -28,7 +28,7 @@ pub mod apikeys_handlers {
 
         // Get the requested API key
         let api_key = APIKEYS_BY_ID_HASHTABLE.with(|store| {
-            store.borrow().get(&requested_id).cloned()
+            store.borrow().get(&requested_id).map(|key| key.clone())
         });
 
         let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
@@ -115,7 +115,7 @@ pub mod apikeys_handlers {
 
         // Get the list of API key IDs for the user
         let api_key_ids = USERS_APIKEYS_HASHTABLE.with(|store| {
-            store.borrow().get(&requested_user_id).cloned()
+            store.borrow().get(&requested_user_id).map(|data| data.clone())
         });
 
         match api_key_ids {
@@ -227,10 +227,21 @@ pub mod apikeys_handlers {
 
         // 3. Add to USERS_APIKEYS_HASHTABLE
         USERS_APIKEYS_HASHTABLE.with(|store| {
-            store.borrow_mut()
-                .entry(new_api_key.user_id.clone())
-                .or_insert_with(Vec::new)
-                .push(new_api_key.id.clone());
+            let mut store_mut = store.borrow_mut();
+            
+            // Check if the user already has API keys
+            if let Some(mut existing_list) = store_mut.get(&new_api_key.user_id) {
+                // Clone and modify the existing list
+                let mut updated_list = existing_list.clone();
+                updated_list.add(new_api_key.id.clone());
+                
+                // Insert the updated list
+                store_mut.insert(new_api_key.user_id.clone(), updated_list);
+            } else {
+                // Create new list with this key
+                let new_list = ApiKeyIDList::with_key(new_api_key.id.clone());
+                store_mut.insert(new_api_key.user_id.clone(), new_list);
+            }
         });
 
         update_external_id_mapping(
@@ -278,7 +289,7 @@ pub mod apikeys_handlers {
 
         // Get the API key to update
         let api_key_id = ApiKeyID(update_req.id);
-        let mut api_key = match APIKEYS_BY_ID_HASHTABLE.with(|store| store.borrow().get(&api_key_id).cloned()) {
+        let mut api_key = match APIKEYS_BY_ID_HASHTABLE.with(|store| store.borrow().get(&api_key_id).map(|key| key.clone())) {
             Some(key) => key,
             None => return create_response(
                 StatusCode::NOT_FOUND,
@@ -338,7 +349,7 @@ pub mod apikeys_handlers {
 
         // Get the updated API key
         let updated_api_key = APIKEYS_BY_ID_HASHTABLE.with(|store| {
-            store.borrow().get(&api_key.id.clone()).cloned()
+            store.borrow().get(&api_key.id.clone()).map(|key| key.clone())
         });
 
         update_external_id_mapping(
@@ -406,7 +417,7 @@ pub mod apikeys_handlers {
 
        // Get the API key to be deleted
         let api_key_to_delete = APIKEYS_BY_ID_HASHTABLE.with(|store| {
-            store.borrow().get(&ApiKeyID(delete_request.id.to_string())).cloned()
+            store.borrow().get(&ApiKeyID(delete_request.id.to_string())).map(|key| key.clone())
         });
 
         let api_key = match api_key_to_delete {
@@ -458,12 +469,20 @@ pub mod apikeys_handlers {
 
         // 3. Remove from USERS_APIKEYS_HASHTABLE
         USERS_APIKEYS_HASHTABLE.with(|store| {
-            let mut store = store.borrow_mut();
-            if let Some(api_key_ids) = store.get_mut(&api_key.user_id) {
-                api_key_ids.retain(|id| id != &api_key.id);
+            let mut store_mut = store.borrow_mut();
+            
+            // Check if the user has any API keys
+            if let Some(existing_list) = store_mut.get(&api_key.user_id) {
+                // Clone and modify the list
+                let mut updated_list = existing_list.clone();
+                updated_list.remove(&api_key.id);
+                
                 // If this was the last API key for the user, remove the user entry
-                if api_key_ids.is_empty() {
-                    store.remove(&api_key.user_id);
+                if updated_list.is_empty() {
+                    store_mut.remove(&api_key.user_id);
+                } else {
+                    // Otherwise update with the new list
+                    store_mut.insert(api_key.user_id.clone(), updated_list);
                 }
             }
         });

--- a/src/canisters-official-backend/src/rest/api_keys/handler.rs
+++ b/src/canisters-official-backend/src/rest/api_keys/handler.rs
@@ -31,7 +31,7 @@ pub mod apikeys_handlers {
             store.borrow().get(&requested_id).map(|key| key.clone())
         });
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         let is_own_key = match &api_key {
             Some(key) => requester_api_key.user_id == key.user_id,
             None => false
@@ -96,7 +96,7 @@ pub mod apikeys_handlers {
         // 1. The requester's API key must belong to the owner
         // 2. Or the requester must be requesting their own API keys
         // 3. Or the requester must have View permission on the API keys table
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         let is_own_keys = requester_api_key.user_id == requested_user_id;
 
         if !is_owner && !is_own_keys {
@@ -167,7 +167,7 @@ pub mod apikeys_handlers {
         }
 
         // Determine what user_id to use for the new key
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
                     
         // Check system permission to create if not owner
         if !is_owner {
@@ -299,7 +299,7 @@ pub mod apikeys_handlers {
         let old_external_id = api_key.external_id.clone();
         let old_internal_id = Some(api_key.id.to_string());
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         let is_own_key = requester_api_key.user_id == api_key.user_id;
 
         // Check system permission to update if not owner or own key
@@ -436,7 +436,7 @@ pub mod apikeys_handlers {
         // 1. The requester's API key must belong to the owner
         // 2. Or the requester must be deleting their own API key
         // 3. Or the requester must have Delete permission on this API key record
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         let is_own_key = requester_api_key.user_id == api_key.user_id;
 
         if !is_owner && !is_own_key {

--- a/src/canisters-official-backend/src/rest/api_keys/types.rs
+++ b/src/canisters-official-backend/src/rest/api_keys/types.rs
@@ -17,7 +17,7 @@ impl ApiKeyFE {
     pub fn redacted(&self, user_id: &UserID) -> Self {
         let mut redacted = self.clone();
 
-        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id.clone() == owner_id.borrow().get().clone());
         let has_edit_permissions = redacted.permission_previews.contains(&SystemPermissionType::Edit);
 
         // Most sensitive

--- a/src/canisters-official-backend/src/rest/auth.rs
+++ b/src/canisters-official-backend/src/rest/auth.rs
@@ -190,9 +190,9 @@ pub fn authenticate_request(req: &HttpRequest) -> Option<ApiKey> {
                 },
             }
         },
-        AuthJsonDecoded::Api_Key(proof) => {
+        AuthJsonDecoded::ApiKey(proof) => {
             // Verify it's the API key type
-            if proof.auth_type != AuthTypeEnum::Api_Key {
+            if proof.auth_type != AuthTypeEnum::ApiKey {
                 debug_log!("Auth type mismatch in API key proof");
                 return None;
             }

--- a/src/canisters-official-backend/src/rest/auth.rs
+++ b/src/canisters-official-backend/src/rest/auth.rs
@@ -2,7 +2,7 @@ use candid::Principal;
 use ed25519_dalek::SigningKey;
 // src/rest/auth.rs
 use ic_http_certification::{HttpRequest, HttpResponse, StatusCode};
-use crate::{core::{api::uuid::format_user_id, state::api_keys::{state::state::{debug_state,APIKEYS_BY_ID_HASHTABLE, APIKEYS_BY_VALUE_HASHTABLE}, types::{ApiKey, ApiKeyID, ApiKeyValue, AuthJsonDecoded, AuthTypeEnum}}, types::UserID}, debug_log, rest::helpers::update_last_online_at};
+use crate::{core::{api::uuid::format_user_id, state::api_keys::{state::state::{APIKEYS_BY_ID_HASHTABLE, APIKEYS_BY_VALUE_HASHTABLE}, types::{ApiKey, ApiKeyID, ApiKeyValue, AuthJsonDecoded, AuthTypeEnum}}, types::UserID}, debug_log, rest::helpers::update_last_online_at};
 use crate::rest::api_keys::types::ErrorResponse;
 use ic_types::crypto::AlgorithmId;
 use bip39::{Mnemonic, Language};
@@ -203,7 +203,7 @@ pub fn authenticate_request(req: &HttpRequest) -> Option<ApiKey> {
             
             // Look up the API key ID using the value
             let api_key_id = APIKEYS_BY_VALUE_HASHTABLE.with(|store| {
-                store.borrow().get(&api_key_value).cloned()
+                store.borrow().get(&api_key_value).map(|data| data.clone())
             });
             
             if let Some(api_key_id) = api_key_id {
@@ -211,7 +211,7 @@ pub fn authenticate_request(req: &HttpRequest) -> Option<ApiKey> {
                 
                 // Look up the full API key using the ID
                 let full_api_key = APIKEYS_BY_ID_HASHTABLE.with(|store| {
-                    store.borrow().get(&api_key_id).cloned()
+                    store.borrow().get(&api_key_id).map(|key| key.clone())
                 });
                 
                 // Check if key exists and validate expiration/revocation

--- a/src/canisters-official-backend/src/rest/contacts/handler.rs
+++ b/src/canisters-official-backend/src/rest/contacts/handler.rs
@@ -28,7 +28,7 @@ pub mod contacts_handlers {
         
 
         // Only owner can access contact.private_note
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
 
         // Get contact ID from params
         let contact_id = UserID(params.get("contact_id").unwrap().to_string());
@@ -90,7 +90,7 @@ pub mod contacts_handlers {
         };
         
         // Check if the requester is the owner (who has full access)
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         
         // Check table-level permissions
         let has_table_permission = if !is_owner {
@@ -303,7 +303,7 @@ pub mod contacts_handlers {
         };
         
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
 
         // Parse request body
         let body: &[u8] = request.body();
@@ -393,7 +393,7 @@ pub mod contacts_handlers {
 
         // Add the contact to the default "Everyone" group if it exists
         let default_group_id = DEFAULT_EVERYONE_GROUP.with(|group_id| group_id.borrow().clone());
-        let owner_id = OWNER_ID.with(|owner_id| owner_id.borrow().clone());
+        let owner_id = OWNER_ID.with(|owner_id| owner_id.borrow().get().clone());
         
         // Check if the default group still exists
         let group_exists = GROUPS_BY_ID_HASHTABLE.with(|groups| {
@@ -469,7 +469,7 @@ pub mod contacts_handlers {
         };
         
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
       
 
         // Parse request body
@@ -589,7 +589,7 @@ pub mod contacts_handlers {
         };
         
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
     
 
         let prestate = snapshot_prestate();
@@ -717,7 +717,7 @@ pub mod contacts_handlers {
         };
         
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
 
         let prestate = snapshot_prestate();
 

--- a/src/canisters-official-backend/src/rest/contacts/types.rs
+++ b/src/canisters-official-backend/src/rest/contacts/types.rs
@@ -17,7 +17,7 @@ impl ContactFE {
     pub fn redacted(&self, user_id: &UserID) -> Self {
         let mut redacted = self.clone();
 
-        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id.clone() == owner_id.borrow().get().clone());
         let is_owned = *user_id == self.contact.id;
         let has_edit_permissions = redacted.permission_previews.contains(&SystemPermissionType::Edit);
 

--- a/src/canisters-official-backend/src/rest/directory/handler.rs
+++ b/src/canisters-official-backend/src/rest/directory/handler.rs
@@ -54,7 +54,7 @@ pub mod directorys_handlers {
                     PermissionGranteeID::User(requester_api_key.user_id.clone())
                 ).await;
 
-                let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+                let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
 
                 // User needs at least View permission to list directory
                 if !is_owner && !user_permissions.contains(&DirectoryPermissionType::View) {

--- a/src/canisters-official-backend/src/rest/directory/handler.rs
+++ b/src/canisters-official-backend/src/rest/directory/handler.rs
@@ -467,7 +467,7 @@ pub mod directorys_handlers {
     
         // 3. Get disk info to access AWS credentials
         let disk = DISKS_BY_ID_HASHTABLE.with(|map| {
-            map.borrow().get(&file_meta.disk_id).cloned()
+            map.borrow().get(&file_meta.disk_id).map(|d| d.clone())
         });
     
         let disk = match disk {

--- a/src/canisters-official-backend/src/rest/directory/types.rs
+++ b/src/canisters-official-backend/src/rest/directory/types.rs
@@ -27,7 +27,7 @@ impl FileRecordFE {
     pub fn redacted(&self, user_id: &UserID) -> Self {
         let mut redacted = self.clone();
 
-        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id.clone() == owner_id.borrow().get().clone());
         let has_edit_permissions = redacted.permission_previews.contains(&DirectoryPermissionType::Edit);
 
         // Most sensitive
@@ -65,7 +65,7 @@ impl FolderRecordFE {
     pub fn redacted(&self, user_id: &UserID) -> Self {
         let mut redacted = self.clone();
 
-        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id.clone() == owner_id.borrow().get().clone());
         let has_edit_permissions = redacted.permission_previews.contains(&DirectoryPermissionType::Edit);
 
         // Most sensitive

--- a/src/canisters-official-backend/src/rest/directory/types.rs
+++ b/src/canisters-official-backend/src/rest/directory/types.rs
@@ -1,6 +1,7 @@
 
 // src/rest/directory/types.rs
 use std::{collections::HashMap, fmt};
+use candid::CandidType;
 use serde::{Deserialize, Serialize, Deserializer, Serializer, ser::SerializeStruct};
 use crate::{core::{state::{directory::types::{DriveClippedFilePath, DriveFullFilePath, FileID, FileRecord, FolderID, FolderRecord}, drives::state::state::OWNER_ID, labels::{state::validate_uuid4_string_with_prefix, types::{redact_label, LabelStringValue}}, permissions::types::{DirectoryPermissionID, DirectoryPermissionType, SystemPermissionType}, raw_storage::types::UploadStatus}, types::{ClientSuggestedUUID, IDPrefix}}, rest::{types::{validate_external_id, validate_external_payload, validate_id_string, validate_short_string, validate_unclaimed_uuid, validate_url_endpoint, ValidationError}, webhooks::types::SortDirection}};
 use crate::core::{
@@ -14,7 +15,7 @@ use serde_diff::{SerdeDiff};
 
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct FileRecordFE {
     #[serde(flatten)] 
     pub file: FileRecord,
@@ -52,7 +53,7 @@ impl FileRecordFE {
 
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct FolderRecordFE {
     #[serde(flatten)] 
     pub folder: FolderRecord,
@@ -90,7 +91,7 @@ impl FolderRecordFE {
 
 
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, CandidType)]
 pub struct SearchDirectoryRequest {
     pub query_string: String,
 }
@@ -116,7 +117,7 @@ impl SearchDirectoryRequest {
 }
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct ListDirectoryRequest {
     pub folder_id: Option<String>,
     pub path: Option<String>,
@@ -182,7 +183,7 @@ impl ListDirectoryRequest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct DirectoryListResponse {
     pub folders: Vec<FolderRecordFE>,
     pub files: Vec<FileRecordFE>,
@@ -193,7 +194,7 @@ pub struct DirectoryListResponse {
     pub permission_previews: Vec<DirectoryPermissionType>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct FilePathBreadcrumb {
     pub resource_id: String,
     pub resource_name: String,
@@ -203,14 +204,14 @@ fn default_page_size() -> usize {
     50
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct DiskUploadResponse {
     pub url: String,
     pub fields: HashMap<String, String>,
 }
 
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, CandidType)]
 pub struct UploadChunkRequest {
     pub file_id: String,
     pub chunk_index: u32,
@@ -218,13 +219,13 @@ pub struct UploadChunkRequest {
     pub total_chunks: u32
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct UploadChunkResponse {
     pub chunk_id: String,
     pub bytes_received: usize
 }
 
-#[derive(Debug, Clone, Deserialize)] 
+#[derive(Debug, Clone, Deserialize, CandidType)] 
 pub struct CompleteUploadRequest {
     pub file_id: String,
     pub filename: String
@@ -241,7 +242,7 @@ impl CompleteUploadRequest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct CompleteUploadResponse {
     pub file_id: String,
     pub size: usize,
@@ -250,7 +251,7 @@ pub struct CompleteUploadResponse {
 }
 
 
-#[derive(serde::Serialize, Deserialize)]
+#[derive(serde::Serialize, Deserialize, CandidType)]
 pub struct FileMetadataResponse {
     pub file_id: String,
     pub total_size: usize,
@@ -265,7 +266,7 @@ pub type ErrorResponse<'a> = DirectoryResponse<'a, ()>;
 
 
 
-#[derive(Debug, Clone, Deserialize)] 
+#[derive(Debug, Clone, Deserialize, CandidType)] 
 pub struct ClientSideUploadRequest {
     pub disk_id: String,
     pub folder_path: String,
@@ -287,7 +288,7 @@ impl ClientSideUploadRequest {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct ClientSideUploadResponse {
     pub signature: String,
 }
@@ -429,13 +430,13 @@ impl DirectoryAction {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 struct RawDirectoryAction {
     action: DirectoryActionEnum,
     payload: Value,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, CandidType)]
 pub struct DirectoryActionOutcomeID(pub String);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -578,13 +579,13 @@ impl Serialize for DirectoryAction {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct DirectoryActionError {
     pub code: i32,
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum DirectoryActionEnum {
     GetFile,
@@ -604,7 +605,7 @@ pub enum DirectoryActionEnum {
 
 
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CandidType)]
 pub enum FileConflictResolutionEnum {
     REPLACE,
     KEEP_BOTH,
@@ -624,7 +625,7 @@ impl fmt::Display for FileConflictResolutionEnum {
 
 
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SerdeDiff, CandidType)]
 pub enum DirectoryResourceID {
     File(FileID),
     Folder(FolderID),
@@ -649,7 +650,7 @@ impl DirectoryResourceID {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub enum DirectoryActionPayload {
     GetFile(GetFilePayload),
     GetFolder(GetFolderPayload),
@@ -666,7 +667,7 @@ pub enum DirectoryActionPayload {
     RestoreTrash(RestoreTrashPayload),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct GetFilePayload {
     pub id: FileID,
@@ -690,7 +691,7 @@ impl GetFilePayload {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct GetFolderPayload {
     pub id: FolderID,
@@ -716,7 +717,7 @@ impl GetFolderPayload {
 
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct CreateFilePayload {
     pub id: Option<ClientSuggestedUUID>, 
@@ -785,7 +786,7 @@ impl CreateFilePayload {
 
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct CreateFolderPayload {
     pub id: Option<ClientSuggestedUUID>,
@@ -841,7 +842,7 @@ impl CreateFolderPayload {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct UpdateFilePayload {
     pub id: FileID,
@@ -890,7 +891,7 @@ impl UpdateFilePayload {
 }
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct UpdateFolderPayload {
     pub id: FolderID,
@@ -938,7 +939,7 @@ impl UpdateFolderPayload {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct DeleteFilePayload {
     pub id: FileID,
@@ -954,7 +955,7 @@ impl DeleteFilePayload {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct DeleteFolderPayload {
     pub id: FolderID,
@@ -970,7 +971,7 @@ impl DeleteFolderPayload {
 }
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct CopyFilePayload {
     pub id: FileID,
@@ -1017,7 +1018,7 @@ impl CopyFilePayload {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct CopyFolderPayload {
     pub id: FolderID,
@@ -1064,7 +1065,7 @@ impl CopyFolderPayload {
     }
 }
 
-#[derive(Debug, Clone,Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct MoveFilePayload {
     pub id: FileID,
@@ -1104,7 +1105,7 @@ impl MoveFilePayload {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct MoveFolderPayload {
     pub id: FolderID,
@@ -1145,7 +1146,7 @@ impl MoveFolderPayload {
 }
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct RestoreTrashPayload {
     pub id: String, // FileID or FolderID
@@ -1174,13 +1175,13 @@ impl RestoreTrashPayload {
 
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct GetFileResponse {
     pub file: FileRecordFE,
     pub breadcrumbs: Vec<FilePathBreadcrumb>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct GetFolderResponse {
     pub folder: FolderRecordFE,
     pub breadcrumbs: Vec<FilePathBreadcrumb>,
@@ -1188,7 +1189,7 @@ pub struct GetFolderResponse {
 
 
 // Response types remain the same as before
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 #[serde(untagged)]
 pub enum DirectoryActionResult {
     GetFile(GetFileResponse),
@@ -1209,26 +1210,26 @@ pub enum DirectoryActionResult {
 
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct CreateFileResponse {
     pub file: FileRecordFE,
     pub upload: DiskUploadResponse,
     pub notes: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct CreateFolderResponse {
     pub notes: String,
     pub folder: FolderRecordFE,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct DeleteFileResponse {
     pub file_id: FileID,
     pub path_to_trash: DriveFullFilePath,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct DeleteFolderResponse {
     pub folder_id: FolderID,
     pub path_to_trash: DriveFullFilePath, // if empty then its permanently deleted
@@ -1239,13 +1240,13 @@ pub struct DeleteFolderResponse {
 }
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct RestoreTrashResponse {
     pub restored_files: Vec<FileID>,
     pub restored_folders: Vec<FolderID>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, CandidType)]
 pub struct DirectoryResourcePermissionFE {
     pub permission_id: String,
     pub grant_type: String,

--- a/src/canisters-official-backend/src/rest/disks/handler.rs
+++ b/src/canisters-official-backend/src/rest/disks/handler.rs
@@ -24,7 +24,7 @@ pub mod disks_handlers {
         };
 
         // Only owner can access disk.private_note
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
 
         // Get disk ID from params
         let disk_id = DiskID(params.get("disk_id").unwrap().to_string());
@@ -76,7 +76,7 @@ pub mod disks_handlers {
         };
     
         // Check if the requester is the owner
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
     
         // Check table-level permissions if not owner
         let has_table_permission = if !is_owner {
@@ -284,7 +284,7 @@ pub mod disks_handlers {
             None => return create_auth_error_response(),
         };
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
     
         // Parse request body
         let body: &[u8] = request.body();
@@ -385,7 +385,7 @@ pub mod disks_handlers {
             None => return create_auth_error_response(),
         };
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
       
 
         // Parse request body
@@ -487,7 +487,7 @@ pub mod disks_handlers {
             None => return create_auth_error_response(),
         };
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
 
         let prestate = snapshot_prestate();
 

--- a/src/canisters-official-backend/src/rest/disks/types.rs
+++ b/src/canisters-official-backend/src/rest/disks/types.rs
@@ -20,7 +20,7 @@ impl DiskFE {
     pub fn redacted(&self, user_id: &UserID) -> Self {
         let mut redacted = self.clone();
 
-        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id.clone() == owner_id.borrow().get().clone());
         let has_edit_permissions = redacted.permission_previews.contains(&SystemPermissionType::Edit);
 
         // Most sensitive

--- a/src/canisters-official-backend/src/rest/drives/types.rs
+++ b/src/canisters-official-backend/src/rest/drives/types.rs
@@ -25,7 +25,7 @@ impl DriveFE {
     pub fn redacted(&self, user_id: &UserID) -> Self {
         let mut redacted = self.clone();
 
-        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id.clone() == owner_id.borrow().get().clone());
         let has_edit_permissions = redacted.permission_previews.contains(&SystemPermissionType::Edit);
 
         // Most sensitive

--- a/src/canisters-official-backend/src/rest/group_invites/handler.rs
+++ b/src/canisters-official-backend/src/rest/group_invites/handler.rs
@@ -3,7 +3,7 @@
 
 pub mod group_invites_handlers {
     use crate::{
-        core::{api::{permissions::system::check_system_permissions, replay::diff::{snapshot_poststate, snapshot_prestate}, uuid::{generate_uuidv4, mark_claimed_uuid}, webhooks::group_invites::{fire_group_invite_webhook, get_active_group_invite_webhooks}}, state::{drives::{state::state::{update_external_id_mapping, OWNER_ID}, types::{ExternalID, ExternalPayload}}, group_invites::{state::state::{INVITES_BY_ID_HASHTABLE, USERS_INVITES_LIST_HASHTABLE}, types::{GroupInviteID, GroupInviteeID, GroupRole, PlaceholderGroupInviteeID}}, groups::{state::state::{is_user_on_group, GROUPS_BY_ID_HASHTABLE}, types::GroupID}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemResourceID, SystemTableEnum}, webhooks::types::WebhookEventLabel}, types::{IDPrefix, PublicKeyICP, UserID}}, debug_log, rest::{auth::{authenticate_request, create_auth_error_response}, group_invites::types::{ CreateGroupInviteRequestBody, CreateGroup_InviteResponse, DeleteGroup_InviteRequest, DeleteGroup_InviteResponse, DeletedGroup_InviteData, ErrorResponse, GetGroup_InviteResponse, ListGroupInvitesRequestBody, ListGroupInvitesResponseData, ListGroup_InvitesResponse, RedeemGroupInviteRequest, RedeemGroupInviteResponseData, UpdateGroupInviteRequestBody, UpdateGroup_InviteRequest, UpdateGroup_InviteResponse}, groups::types::{ListGroupsRequestBody, ListGroupsResponseData}, webhooks::types::{GroupInviteWebhookData, SortDirection}}
+        core::{api::{permissions::system::check_system_permissions, replay::diff::{snapshot_poststate, snapshot_prestate}, uuid::{generate_uuidv4, mark_claimed_uuid}, webhooks::group_invites::{fire_group_invite_webhook, get_active_group_invite_webhooks}}, state::{drives::{state::state::{update_external_id_mapping, OWNER_ID}, types::{ExternalID, ExternalPayload}}, group_invites::{state::state::{INVITES_BY_ID_HASHTABLE, USERS_INVITES_LIST_HASHTABLE}, types::{GroupInviteID, GroupInviteIDList, GroupInviteeID, GroupRole, PlaceholderGroupInviteeID}}, groups::{state::state::{is_user_on_group, GROUPS_BY_ID_HASHTABLE}, types::GroupID}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemResourceID, SystemTableEnum}, webhooks::types::WebhookEventLabel}, types::{IDPrefix, PublicKeyICP, UserID}}, debug_log, rest::{auth::{authenticate_request, create_auth_error_response}, group_invites::types::{ CreateGroupInviteRequestBody, CreateGroup_InviteResponse, DeleteGroup_InviteRequest, DeleteGroup_InviteResponse, DeletedGroup_InviteData, ErrorResponse, GetGroup_InviteResponse, ListGroupInvitesRequestBody, ListGroupInvitesResponseData, ListGroup_InvitesResponse, RedeemGroupInviteRequest, RedeemGroupInviteResponseData, UpdateGroupInviteRequestBody, UpdateGroup_InviteRequest, UpdateGroup_InviteResponse}, groups::types::{ListGroupsRequestBody, ListGroupsResponseData}, webhooks::types::{GroupInviteWebhookData, SortDirection}}
         
     };
     use crate::core::state::group_invites::{
@@ -22,7 +22,7 @@ pub mod group_invites_handlers {
         let invite_id = GroupInviteID(params.get("invite_id").unwrap().to_string());
         
         let invite = INVITES_BY_ID_HASHTABLE.with(|store| {
-            store.borrow().get(&invite_id).cloned()
+            store.borrow().get(&invite_id).clone()
         });
     
         match invite {
@@ -131,8 +131,7 @@ pub mod group_invites_handlers {
                 .map(|group| INVITES_BY_ID_HASHTABLE.with(|invite_store| {
                     let invites = invite_store.borrow();
                     group.member_invites.iter()
-                        .filter_map(|id| invites.get(id))
-                        .cloned()
+                        .filter_map(|id| invites.get(id).clone())
                         .collect::<Vec<_>>()
                 }))
                 .unwrap_or_default()
@@ -276,13 +275,13 @@ pub mod group_invites_handlers {
 
         let before_snap = GroupInviteWebhookData {
             group: GROUPS_BY_ID_HASHTABLE.with(|store| 
-                store.borrow().get(&group_id).cloned()
+                store.borrow().get(&group_id).clone()
             ),
             group_invite: None,
         };
 
         // Verify group exists and user has permission
-        let group = match GROUPS_BY_ID_HASHTABLE.with(|store| store.borrow().get(&group_id).cloned()) {
+        let group = match GROUPS_BY_ID_HASHTABLE.with(|store| store.borrow().get(&group_id).clone()) {
             Some(group) => group,
             None => return create_response(
                 StatusCode::NOT_FOUND,
@@ -367,7 +366,7 @@ pub mod group_invites_handlers {
         // Update group's invite lists
         GROUPS_BY_ID_HASHTABLE.with(|store| {
             let mut store = store.borrow_mut();
-            if let Some(group) = store.get_mut(&group_id) {
+            if let Some(mut group) = store.get(&group_id).clone() {
                 match new_invite.role {
                     GroupRole::Admin => {
                         group.admin_invites.push(invite_id.clone());
@@ -375,15 +374,27 @@ pub mod group_invites_handlers {
                     },
                     GroupRole::Member => group.member_invites.push(invite_id.clone()),
                 }
+                // Insert the modified group back into the map
+                store.insert(group_id.clone(), group);
             }
         });
 
         // Update user's group invites
         USERS_INVITES_LIST_HASHTABLE.with(|store| {
             let mut store = store.borrow_mut();
-            store.entry(new_invite.invitee_id.clone())
-                .or_insert_with(Vec::new)
-                .push(invite_id.clone());
+            let invitee_id = new_invite.invitee_id.clone();
+            
+            // Get the current list if it exists, or create a new empty one
+            let mut invite_list = match store.get(&invitee_id) {
+                Some(list) => list.clone(),
+                None => GroupInviteIDList { invites: Vec::new() }
+            };
+            
+            // Add the new invite
+            invite_list.invites.push(invite_id.clone());
+            
+            // Insert the updated list back
+            store.insert(invitee_id, invite_list);
         });
 
         mark_claimed_uuid(&invite_id.clone().to_string());
@@ -392,10 +403,10 @@ pub mod group_invites_handlers {
         if !active_webhooks.is_empty() {
             let after_snap = GroupInviteWebhookData {
                 group: GROUPS_BY_ID_HASHTABLE.with(|store| 
-                    store.borrow().get(&group_id).cloned()
+                    store.borrow().get(&group_id).clone()
                 ),
                 group_invite: INVITES_BY_ID_HASHTABLE.with(|store| 
-                    store.borrow().get(&invite_id).cloned()
+                    store.borrow().get(&invite_id).clone()
                 ),
             };
 
@@ -448,7 +459,7 @@ pub mod group_invites_handlers {
 
         // Get existing invite
         let mut invite = match INVITES_BY_ID_HASHTABLE.with(|store| 
-            store.borrow().get(&invite_id).cloned()
+            store.borrow().get(&invite_id).clone()
         ) {
             Some(invite) => invite,
             None => return create_response(
@@ -459,7 +470,7 @@ pub mod group_invites_handlers {
         let active_webhooks = get_active_group_invite_webhooks(&invite.group_id, WebhookEventLabel::GroupInviteUpdated);
         let before_snap = GroupInviteWebhookData {
             group: GROUPS_BY_ID_HASHTABLE.with(|store| 
-                store.borrow().get(&invite.group_id).cloned()
+                store.borrow().get(&invite.group_id).clone()
             ),
             group_invite: Some(invite.clone()),
         };
@@ -491,7 +502,7 @@ pub mod group_invites_handlers {
             if new_role != invite.role {
                 GROUPS_BY_ID_HASHTABLE.with(|store| {
                     let mut store = store.borrow_mut();
-                    if let Some(group) = store.get_mut(&invite.group_id) {
+                    if let Some(mut group) = store.get(&invite.group_id).clone() {
                         // Remove from old role's list
                         match invite.role {
                             GroupRole::Admin => {
@@ -524,6 +535,8 @@ pub mod group_invites_handlers {
                                 }
                             },
                         }
+                        // Insert the modified group back into the map
+                        store.insert(invite.group_id.clone(), group);
                     }
                 });
                 invite.role = new_role;
@@ -567,10 +580,10 @@ pub mod group_invites_handlers {
         if !active_webhooks.is_empty() {
             let after_snap = GroupInviteWebhookData {
                 group: GROUPS_BY_ID_HASHTABLE.with(|store| 
-                    store.borrow().get(&invite.group_id).cloned()
+                    store.borrow().get(&invite.group_id).clone()
                 ),
                 group_invite: INVITES_BY_ID_HASHTABLE.with(|store| 
-                    store.borrow().get(&invite_id).cloned()
+                    store.borrow().get(&invite_id).clone()
                 ),
             };
             fire_group_invite_webhook(
@@ -624,7 +637,7 @@ pub mod group_invites_handlers {
         }
     
         // Get invite to verify it exists
-        let invite = match INVITES_BY_ID_HASHTABLE.with(|store| store.borrow().get(&delete_req.id).cloned()) {
+        let invite = match INVITES_BY_ID_HASHTABLE.with(|store| store.borrow().get(&delete_req.id).clone()) {
             Some(invite) => invite,
             None => return create_response(
                 StatusCode::NOT_FOUND,
@@ -663,11 +676,16 @@ pub mod group_invites_handlers {
         // Update group's invite lists
         GROUPS_BY_ID_HASHTABLE.with(|store| {
             let mut store = store.borrow_mut();
-            if let Some(group) = store.get_mut(&invite.group_id) {
+            if let Some(group) = store.get(&invite.group_id) {
+                let mut group = group.clone();
                 match invite.role {
                     GroupRole::Admin => {
                         if let Some(pos) = group.admin_invites.iter().position(|id| *id == delete_req.id) {
                             group.admin_invites.remove(pos);
+                        }
+                        // If it's an admin invite, also check and remove from member_invites if present
+                        if let Some(pos) = group.member_invites.iter().position(|id| *id == delete_req.id) {
+                            group.member_invites.remove(pos);
                         }
                     },
                     GroupRole::Member => {
@@ -676,15 +694,19 @@ pub mod group_invites_handlers {
                         }
                     },
                 }
+                // Insert the modified group back into the map
+                store.insert(invite.group_id.clone(), group);
             }
         });
         
         // Update user's group invites
         USERS_INVITES_LIST_HASHTABLE.with(|store| {
             let mut store = store.borrow_mut();
-            if let Some(invites) = store.get_mut(&invite.invitee_id) {
-                if let Some(pos) = invites.iter().position(|id| *id == delete_req.id) {
-                    invites.remove(pos);
+            if let Some(mut invites) = store.get(&invite.invitee_id).clone() {
+                if let Some(pos) = invites.invites.iter().position(|id| *id == delete_req.id) {
+                    invites.invites.remove(pos);
+                    // Insert the modified invites list back
+                    store.insert(invite.invitee_id.clone(), invites);
                 }
             }
         });
@@ -737,7 +759,7 @@ pub mod group_invites_handlers {
     
         // Get existing invite
         let invite = match INVITES_BY_ID_HASHTABLE.with(|store| {
-            store.borrow().get(&invite_id).cloned()
+            store.borrow().get(&invite_id).clone()
         }) {
             Some(invite) => invite,
             None => return create_response(
@@ -800,16 +822,28 @@ pub mod group_invites_handlers {
             // Update user's group invites list with the new invite
             USERS_INVITES_LIST_HASHTABLE.with(|store| {
                 let mut store = store.borrow_mut();
-                store.entry(new_invite.invitee_id.clone())
-                    .or_insert_with(Vec::new)
-                    .push(new_invite_id.clone());
+                let invitee_id = new_invite.invitee_id.clone();
+                
+                // Get the current list if it exists, or create a new empty one
+                let mut invite_list = match store.get(&invitee_id) {
+                    Some(list) => list.clone(),
+                    None => GroupInviteIDList { invites: Vec::new() }
+                };
+                
+                // Add the new invite
+                invite_list.invites.push(new_invite_id.clone());
+                
+                // Insert the updated list back
+                store.insert(invitee_id, invite_list);
             });
     
             // Update group's member invites
             GROUPS_BY_ID_HASHTABLE.with(|store| {
                 let mut store = store.borrow_mut();
-                if let Some(group) = store.get_mut(&invite.group_id) {
-                    group.member_invites.push(new_invite_id.clone());
+                if let Some(group) = store.get(&invite.group_id) {
+                    let mut updated_group = group.clone();
+                    updated_group.member_invites.push(new_invite_id.clone());
+                    store.insert(invite.group_id.clone(), updated_group);
                 }
             });
     
@@ -855,9 +889,19 @@ pub mod group_invites_handlers {
             // Update user's group invites list
             USERS_INVITES_LIST_HASHTABLE.with(|store| {
                 let mut store = store.borrow_mut();
-                store.entry(updated_invite.invitee_id.clone())
-                    .or_insert_with(Vec::new)
-                    .push(invite_id.clone());
+                let invitee_id = updated_invite.invitee_id.clone();
+                
+                // Get the current list if it exists, or create a new empty one
+                let mut invite_list = match store.get(&invitee_id) {
+                    Some(list) => list.clone(),
+                    None => GroupInviteIDList { invites: Vec::new() }
+                };
+                
+                // Add the new invite
+                invite_list.invites.push(invite_id.clone());
+                
+                // Insert the updated list back
+                store.insert(invitee_id, invite_list);
             });
     
             snapshot_poststate(prestate, Some(

--- a/src/canisters-official-backend/src/rest/group_invites/handler.rs
+++ b/src/canisters-official-backend/src/rest/group_invites/handler.rs
@@ -465,7 +465,7 @@ pub mod group_invites_handlers {
         };
         
         // Check if user is authorized (owner or admin)
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         let is_authorized = is_owner || 
         INVITES_BY_ID_HASHTABLE.with(|store| {
             store.borrow()

--- a/src/canisters-official-backend/src/rest/group_invites/types.rs
+++ b/src/canisters-official-backend/src/rest/group_invites/types.rs
@@ -37,7 +37,7 @@ impl GroupInviteFE {
     pub fn redacted(&self, user_id: &UserID) -> Self {
         let mut redacted = self.clone();
 
-        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id.clone() == owner_id.borrow().get().clone());
         let has_edit_permissions = redacted.permission_previews.contains(&SystemPermissionType::Edit);
         let is_group_admin = is_group_admin(user_id, &self.group_id);
 

--- a/src/canisters-official-backend/src/rest/groups/handler.rs
+++ b/src/canisters-official-backend/src/rest/groups/handler.rs
@@ -25,7 +25,7 @@ pub mod groups_handlers {
         let id = GroupID(params.get("group_id").unwrap().to_string());
 
         // Only owner can read groups for now
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         // Check table-level permissions for Groups table
         let permissions = check_system_permissions(
             SystemResourceID::Table(SystemTableEnum::Groups),
@@ -89,7 +89,7 @@ pub mod groups_handlers {
         };
     
         // Check if user is the system owner
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         
         // Check table-level permissions for Groups table
         let has_table_permission = check_system_permissions(
@@ -226,7 +226,7 @@ pub mod groups_handlers {
         };
 
         // Only owner can create/update groups for now
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
 
         // Parse request body
         let body: &[u8] = request.body();
@@ -275,7 +275,7 @@ pub mod groups_handlers {
             drive_id: DRIVE_ID.with(|id| id.clone()),
             endpoint_url: DriveRESTUrlEndpoint(
                 create_req.endpoint_url
-                    .unwrap_or(URL_ENDPOINT.with(|url| url.borrow().clone()).0)
+                    .unwrap_or(URL_ENDPOINT.with(|url| url.borrow().get().0.clone()))
                     .trim_end_matches('/')
                     .to_string()
             ),
@@ -318,7 +318,7 @@ pub mod groups_handlers {
         };
 
         // Only owner can create/update groups for now
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
 
         // Parse request body
         let body: &[u8] = request.body();
@@ -443,7 +443,7 @@ pub mod groups_handlers {
         let group_id = GroupID(delete_request.id.clone());
     
         // Only owner can delete groups for now
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         // Check table-level permissions for Groups table
         let table_permissions = check_system_permissions(
             SystemResourceID::Table(SystemTableEnum::Groups),

--- a/src/canisters-official-backend/src/rest/groups/types.rs
+++ b/src/canisters-official-backend/src/rest/groups/types.rs
@@ -18,7 +18,7 @@ impl GroupFE {
     pub fn redacted(&self, user_id: &UserID) -> Self {
         let mut redacted = self.clone();
 
-        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id.clone() == owner_id.borrow().get().clone());
         let has_edit_permissions = redacted.permission_previews.contains(&SystemPermissionType::Edit);
         let is_group_admin = is_group_admin(user_id, &self.group.id);
 

--- a/src/canisters-official-backend/src/rest/helpers.rs
+++ b/src/canisters-official-backend/src/rest/helpers.rs
@@ -59,10 +59,15 @@ pub fn parse_query_string(query: &str) -> std::collections::HashMap<String, Stri
 }
 
 pub fn update_last_online_at(userID: &UserID) {
-    // Update the last online time for the user if theres a contact
+    // Update the last online time for the user if there's a contact
     CONTACTS_BY_ID_HASHTABLE.with(|map| {
-        if let Some(contact) = map.borrow_mut().get_mut(userID) {
+        // First get a mutable borrow
+        let mut map_mut = map.borrow_mut();
+        
+        // Then check if the contact exists, get it, modify it, and insert it back
+        if let Some(mut contact) = map_mut.get(userID).map(|data| data.clone()) {
             contact.last_online_ms = ic_cdk::api::time() / 1_000_000;
+            map_mut.insert(userID.clone(), contact);
         }
     });
 }

--- a/src/canisters-official-backend/src/rest/labels/handler.rs
+++ b/src/canisters-official-backend/src/rest/labels/handler.rs
@@ -55,7 +55,7 @@ pub mod labels_handlers {
         };
 
         // Only owner can access private label info
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
 
         // Get label ID from params
         let label_str = params.get("label_id").unwrap().to_string();
@@ -130,7 +130,7 @@ pub mod labels_handlers {
         };
     
         // Check if the requester is the owner
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
     
         // Parse request body
         let body = request.body();
@@ -323,7 +323,7 @@ pub mod labels_handlers {
             None => return create_auth_error_response(),
         };
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
 
         // Parse request body
         let body: &[u8] = request.body();
@@ -445,7 +445,7 @@ pub mod labels_handlers {
             None => return create_auth_error_response(),
         };
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
 
         // Parse request body
         let body: &[u8] = request.body();
@@ -580,7 +580,7 @@ pub mod labels_handlers {
             None => return create_auth_error_response(),
         };
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
 
         // Parse request body
         let body: &[u8] = request.body();
@@ -679,7 +679,7 @@ pub mod labels_handlers {
             None => return create_auth_error_response(),
         };
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
 
         // Parse request body
         let body: &[u8] = request.body();

--- a/src/canisters-official-backend/src/rest/labels/types.rs
+++ b/src/canisters-official-backend/src/rest/labels/types.rs
@@ -23,7 +23,7 @@ impl LabelFE {
     pub fn redacted(&self, user_id: &UserID) -> Self {
         let mut redacted = self.clone();
 
-        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id.clone() == owner_id.borrow().get().clone());
         let has_edit_permissions = redacted.permission_previews.contains(&SystemPermissionType::Edit);
 
         // Most sensitive

--- a/src/canisters-official-backend/src/rest/organization/handler.rs
+++ b/src/canisters-official-backend/src/rest/organization/handler.rs
@@ -925,8 +925,10 @@ pub mod drives_handlers {
             if let Some(api_key_ids) = map.borrow().get(&owner_id) {
                 if !api_key_ids.is_empty() {
                     crate::core::state::api_keys::state::state::APIKEYS_BY_ID_HASHTABLE.with(|id_map| {
-                        if let Some(api_key) = id_map.borrow().get(&api_key_ids[0]) {
-                            admin_api_key = api_key.value.0.clone();
+                        if let Some(first_key_id) = api_key_ids.keys.first() {
+                            if let Some(api_key) = id_map.borrow().get(first_key_id) {
+                                admin_api_key = api_key.value.0.clone();
+                            }
                         }
                     });
                 }

--- a/src/canisters-official-backend/src/rest/organization/handler.rs
+++ b/src/canisters-official-backend/src/rest/organization/handler.rs
@@ -130,7 +130,7 @@ pub mod drives_handlers {
 
         let snapshot = snapshot_entire_state();
 
-        debug_log!("snapshot {:?}", snapshot);
+        debug_log!(">> snapshot {:?}", snapshot);
 
         let serializable_state = convert_state_to_serializable(&snapshot);
 

--- a/src/canisters-official-backend/src/rest/organization/handler.rs
+++ b/src/canisters-official-backend/src/rest/organization/handler.rs
@@ -3,7 +3,7 @@
 
 pub mod drives_handlers {
     use crate::{
-        core::{api::{permissions::{directory::{can_user_access_directory_permission, check_directory_permissions}, system::{can_user_access_system_permission, check_system_permissions}}, replay::diff::{apply_state_diff, convert_state_to_serializable, safely_apply_diffs, snapshot_entire_state, snapshot_poststate, snapshot_prestate}, uuid::generate_uuidv4, webhooks::organization::{fire_org_inbox_new_notif_webhook, fire_superswap_user_webhook, get_org_inbox_webhooks, get_superswap_user_webhooks}}, state::{api_keys::state::state::{APIKEYS_BY_ID_HASHTABLE, APIKEYS_BY_VALUE_HASHTABLE, USERS_APIKEYS_HASHTABLE}, contacts::state::state::{CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE, CONTACTS_BY_ID_HASHTABLE, CONTACTS_BY_TIME_LIST}, directory::state::state::{file_uuid_to_metadata, folder_uuid_to_metadata, full_file_path_to_uuid, full_folder_path_to_uuid}, disks::state::state::{DISKS_BY_ID_HASHTABLE, DISKS_BY_TIME_LIST}, drives::{state::state::{superswap_userid, update_external_id_mapping, CANISTER_ID, DRIVES_BY_ID_HASHTABLE, DRIVES_BY_TIME_LIST, DRIVE_ID, DRIVE_STATE_CHECKSUM, DRIVE_STATE_TIMESTAMP_NS, EXTERNAL_ID_MAPPINGS, OWNER_ID, SPAWN_NOTE, SPAWN_REDEEM_CODE, TRANSFER_OWNER_ID, URL_ENDPOINT}, types::{Drive, DriveID, DriveRESTUrlEndpoint, DriveStateDiffID, ExternalID, ExternalPayload, InboxNotifID, SpawnRedeemCode}}, group_invites::state::state::{INVITES_BY_ID_HASHTABLE, USERS_INVITES_LIST_HASHTABLE}, groups::state::state::{is_group_admin, GROUPS_BY_ID_HASHTABLE, GROUPS_BY_TIME_LIST}, labels::{state::{add_label_to_resource, parse_label_resource_id, remove_label_from_resource, validate_label_value}, types::{LabelOperationResponse, LabelResourceID}}, permissions::{state::state::{DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE, SYSTEM_PERMISSIONS_BY_ID_HASHTABLE}, types::{DirectoryPermissionType, PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}}, search::types::SearchCategoryEnum, webhooks::types::WebhookEventLabel}, types::{ICPPrincipalString, IDPrefix, PublicKeyICP, UserID}}, debug_log, rest::{auth::{authenticate_request, create_auth_error_response}, directory::types::DirectoryResourceID, organization::types::{AboutDriveResponse, AboutDriveResponseData, ErrorResponse, ExternalIDsDriveRequestBody, ExternalIDsDriveResponse, ExternalIDsDriveResponseData, ExternalIDvsInternalIDMaps, GetWhoAmIResponse, InboxOrgRequestBody, InboxOrgResponse, InboxOrgResponseData, RedeemOrgRequestBody, RedeemOrgResponse, RedeemOrgResponseData, ReindexDriveRequestBody, ReindexDriveResponse, ReindexDriveResponseData, ReplayDriveRequestBody, ReplayDriveResponse, ReplayDriveResponseData, SearchDriveRequestBody, SearchDriveResponse, SearchDriveResponseData, SearchSortByEnum, SuperswapUserIDRequestBody, SuperswapUserIDResponse, SuperswapUserIDResponseData, TransferOwnershipDriveRequestBody, TransferOwnershipDriveResponse, TransferOwnershipResponseData, TransferOwnershipStatusEnum, WhoAmIReport}, webhooks::types::SortDirection}
+        core::{api::{permissions::{directory::{can_user_access_directory_permission, check_directory_permissions}, system::{can_user_access_system_permission, check_system_permissions}}, replay::diff::{apply_state_diff, convert_state_to_serializable, safely_apply_diffs, snapshot_entire_state, snapshot_poststate, snapshot_prestate}, uuid::generate_uuidv4, webhooks::organization::{fire_org_inbox_new_notif_webhook, fire_superswap_user_webhook, get_org_inbox_webhooks, get_superswap_user_webhooks}}, state::{api_keys::state::state::{APIKEYS_BY_ID_HASHTABLE, APIKEYS_BY_VALUE_HASHTABLE, USERS_APIKEYS_HASHTABLE}, contacts::state::state::{CONTACTS_BY_ICP_PRINCIPAL_HASHTABLE, CONTACTS_BY_ID_HASHTABLE, CONTACTS_BY_TIME_LIST}, directory::state::state::{file_uuid_to_metadata, folder_uuid_to_metadata, full_file_path_to_uuid, full_folder_path_to_uuid}, disks::state::state::{DISKS_BY_ID_HASHTABLE, DISKS_BY_TIME_LIST}, drives::{state::state::{superswap_userid, update_external_id_mapping, CANISTER_ID, DRIVES_BY_ID_HASHTABLE, DRIVES_BY_TIME_LIST, DRIVE_ID, DRIVE_STATE_CHECKSUM, DRIVE_STATE_TIMESTAMP_NS, EXTERNAL_ID_MAPPINGS, OWNER_ID, SPAWN_NOTE, SPAWN_REDEEM_CODE, TRANSFER_OWNER_ID, URL_ENDPOINT}, types::{Drive, DriveID, DriveRESTUrlEndpoint, DriveStateDiffID, ExternalID, ExternalPayload, InboxNotifID, SpawnRedeemCode}}, group_invites::state::state::{INVITES_BY_ID_HASHTABLE, USERS_INVITES_LIST_HASHTABLE}, groups::state::state::{is_group_admin, GROUPS_BY_ID_HASHTABLE, GROUPS_BY_TIME_LIST}, labels::{state::{add_label_to_resource, parse_label_resource_id, remove_label_from_resource, validate_label_value}, types::{LabelOperationResponse, LabelResourceID}}, permissions::{state::state::{DIRECTORY_PERMISSIONS_BY_ID_HASHTABLE, SYSTEM_PERMISSIONS_BY_ID_HASHTABLE}, types::{DirectoryPermissionType, PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}}, search::types::{SearchCategoryEnum, SearchResult}, webhooks::types::WebhookEventLabel}, types::{ICPPrincipalString, IDPrefix, PublicKeyICP, UserID}}, debug_log, rest::{auth::{authenticate_request, create_auth_error_response}, directory::types::DirectoryResourceID, organization::types::{AboutDriveResponse, AboutDriveResponseData, ErrorResponse, ExternalIDsDriveRequestBody, ExternalIDsDriveResponse, ExternalIDsDriveResponseData, ExternalIDvsInternalIDMaps, GetWhoAmIResponse, InboxOrgRequestBody, InboxOrgResponse, InboxOrgResponseData, RedeemOrgRequestBody, RedeemOrgResponse, RedeemOrgResponseData, ReindexDriveRequestBody, ReindexDriveResponse, ReindexDriveResponseData, ReplayDriveRequestBody, ReplayDriveResponse, ReplayDriveResponseData, SearchDriveRequestBody, SearchDriveResponse, SearchDriveResponseData, SearchSortByEnum, SuperswapUserIDRequestBody, SuperswapUserIDResponse, SuperswapUserIDResponseData, TransferOwnershipDriveRequestBody, TransferOwnershipDriveResponse, TransferOwnershipResponseData, TransferOwnershipStatusEnum, WhoAmIReport}, webhooks::types::SortDirection}
         
     };
     use candid::Principal;
@@ -21,7 +21,7 @@ pub mod drives_handlers {
             Some(key) => key,
             None => return create_auth_error_response(),
         };
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         
 
         // Get the drive ID
@@ -64,8 +64,8 @@ pub mod drives_handlers {
         });
         
         let drive_id = DRIVE_ID.with(|id| id.clone());
-        let owner = OWNER_ID.with(|owner| owner.borrow().clone());
-        let endpoint = URL_ENDPOINT.with(|url| url.borrow().0.clone());
+        let owner = OWNER_ID.with(|owner| owner.borrow().get().clone());
+        let endpoint = URL_ENDPOINT.with(|url| url.borrow().get().0.clone());
         let canister_id = CANISTER_ID.with(|id| id.0.clone());
         
         // Get current cycle balance
@@ -170,7 +170,7 @@ pub mod drives_handlers {
             None => return create_auth_error_response(),
         };
     
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         if !is_owner {
             return create_auth_error_response();
         }
@@ -215,7 +215,7 @@ pub mod drives_handlers {
                         .unwrap_or_default();
                     
                     // Determine direction for logging
-                    let current_timestamp = DRIVE_STATE_TIMESTAMP_NS.with(|ts| ts.get());
+                    let current_timestamp = DRIVE_STATE_TIMESTAMP_NS.with(|ts| *ts.borrow().get());
                     let direction_str = if replay_request.diffs[0].timestamp_ns < current_timestamp {
                         "backward"
                     } else {
@@ -237,10 +237,10 @@ pub mod drives_handlers {
                 
                 // Prepare response data
                 let response_data = ReplayDriveResponseData {
-                    timestamp_ns: DRIVE_STATE_TIMESTAMP_NS.with(|ts| ts.get()),
+                    timestamp_ns: DRIVE_STATE_TIMESTAMP_NS.with(|ts| ts.borrow().get().clone()),
                     diffs_applied: applied_count,
                     checkpoint_diff_id: last_diff_id,
-                    final_checksum: DRIVE_STATE_CHECKSUM.with(|cs| cs.borrow().clone()),
+                    final_checksum: DRIVE_STATE_CHECKSUM.with(|cs| cs.borrow().get().clone()),
                 };
                 
                 create_response(
@@ -267,7 +267,7 @@ pub mod drives_handlers {
         };
     
         // Check if user is owner
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         
         // Parse request body
         let body = request.body();
@@ -373,7 +373,7 @@ pub mod drives_handlers {
         };
     
         // Create paginated results from filtered results
-        let mut paginated_results = Vec::new();
+        let mut paginated_results: Vec<SearchResult> = Vec::new();
         let mut end_index = start_index;  // Track where we ended for cursor calculation
         
         // Calculate page end index
@@ -381,6 +381,7 @@ pub mod drives_handlers {
         
         // Get paginated slice
         paginated_results = filtered_results[start_index..end_bound].to_vec();
+        
         end_index = end_bound - 1;
     
         // Calculate next cursor based on whether there are more results
@@ -414,7 +415,7 @@ pub mod drives_handlers {
         };
     
         // Check if user is owner
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         
         // Get drive ID
         let drive_id = DRIVE_ID.with(|drive_id| drive_id.clone());
@@ -517,7 +518,7 @@ pub mod drives_handlers {
         };
     
         // Check if user is owner
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         
         // If not owner, check for View permissions:
         // 1. On the entire Drives table, OR
@@ -579,7 +580,7 @@ pub mod drives_handlers {
                         success: true,
                         message: "External ID found".to_string(),
                         external_id: external_id.clone(),
-                        internal_ids: internal_ids.clone(),
+                        internal_ids: internal_ids.items.clone(),
                     }
                 } else {
                     ExternalIDvsInternalIDMaps {
@@ -616,7 +617,7 @@ pub mod drives_handlers {
         };
     
         // Verify that the requester is the current owner
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         if !is_owner {
             return create_response(
                 StatusCode::UNAUTHORIZED,
@@ -656,7 +657,7 @@ pub mod drives_handlers {
         let one_day_ms: u64 = 24 * 60 * 60 * 1_000; // 24 hours in milliseconds
     
         let (status, ready_ms) = TRANSFER_OWNER_ID.with(|transfer_owner_id| {
-            let current_transfer = transfer_owner_id.borrow().0.clone();
+            let current_transfer = transfer_owner_id.borrow().get().0.clone();
             
             // Check if there's an existing transfer request
             if !current_transfer.is_empty() {
@@ -669,10 +670,12 @@ pub mod drives_handlers {
                         if existing_owner_id == next_owner_id && current_timestamp_ms - transfer_timestamp_ms > one_day_ms {
                             // Complete the transfer
                             OWNER_ID.with(|owner_id| {
-                                *owner_id.borrow_mut() = UserID(next_owner_id.clone());
+                                owner_id.borrow_mut().set(UserID(next_owner_id.clone()));
                             });
                             // Clear the transfer request
-                            *transfer_owner_id.borrow_mut() = UserID("".to_string());
+                            TRANSFER_OWNER_ID.with(|transfer_owner_id| {
+                                transfer_owner_id.borrow_mut().set(UserID("".to_string()));
+                            });
                             return (TransferOwnershipStatusEnum::Completed, current_timestamp_ms);
                         }
                     }
@@ -681,7 +684,9 @@ pub mod drives_handlers {
     
             // Set or update the transfer request
             let new_transfer_value = format!("{}::{}", next_owner_id, current_timestamp_ms);
-            *transfer_owner_id.borrow_mut() = UserID(new_transfer_value);
+            TRANSFER_OWNER_ID.with(|transfer_owner_id| {
+                transfer_owner_id.borrow_mut().set(UserID(new_transfer_value));
+            });
             
             // Calculate ready time in milliseconds
             let ready_time_ms = current_timestamp_ms + one_day_ms;
@@ -726,7 +731,7 @@ pub mod drives_handlers {
             None => return create_auth_error_response(),
         };
     
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
     
         // Get organization ID from params
         let param_org_id = params.get("organization_id").unwrap().to_string();
@@ -794,7 +799,7 @@ pub mod drives_handlers {
         };
     
         // Check if user is owner
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         
         match is_owner {
             true => {
@@ -893,7 +898,7 @@ pub mod drives_handlers {
         }
     
         // Check if redeem code exists and hasn't been redeemed yet
-        let stored_redeem_code = SPAWN_REDEEM_CODE.with(|code| code.borrow().0.clone());
+        let stored_redeem_code = SPAWN_REDEEM_CODE.with(|code| code.borrow().get().0.clone());
         
         // Check if the code has already been redeemed (empty string)
         if stored_redeem_code.is_empty() {
@@ -914,11 +919,11 @@ pub mod drives_handlers {
         // Get the necessary drive data
         let drive_id = DRIVE_ID.with(|id| id.clone());
         let canister_id = CANISTER_ID.with(|id| id.0.clone());
-        let endpoint_url = URL_ENDPOINT.with(|url| url.borrow().0.clone());
-        let spawn_note = SPAWN_NOTE.with(|note| note.borrow().clone());
+        let endpoint_url = URL_ENDPOINT.with(|url| url.borrow().get().0.clone());
+        let spawn_note = SPAWN_NOTE.with(|note| note.borrow().get().clone());
         
         // Get the owner's default admin API key
-        let owner_id = OWNER_ID.with(|id| id.borrow().clone());
+        let owner_id = OWNER_ID.with(|id| id.borrow().get().clone());
         let mut admin_api_key = String::new();
         
         crate::core::state::api_keys::state::state::USERS_APIKEYS_HASHTABLE.with(|map| {
@@ -949,9 +954,10 @@ pub mod drives_handlers {
     
         // Reset the redemption code to empty string (mark as redeemed)
         SPAWN_REDEEM_CODE.with(|code| {
-            *code.borrow_mut() = SpawnRedeemCode("".to_string());
+            code.borrow_mut().set(SpawnRedeemCode("".to_string()));
             debug_log!("Spawn redeem code has been used and reset");
         });
+        
     
         // Encode and return the response
         create_response(
@@ -987,7 +993,7 @@ pub mod drives_handlers {
 
     
         // Check if user is owner
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow().get());
         
         // If not owner, check for View permissions:
         // 1. On the entire Drives table, OR

--- a/src/canisters-official-backend/src/rest/permissions/handler.rs
+++ b/src/canisters-official-backend/src/rest/permissions/handler.rs
@@ -39,7 +39,7 @@ pub mod permissions_handlers {
         // 4. Verify access rights using helper function
         match &permission {
             Some(p) => {
-                let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+                let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
                 
                 if !can_user_access_directory_permission(&requester_api_key.user_id, p, is_owner) {
                     return create_auth_error_response();
@@ -111,7 +111,7 @@ pub mod permissions_handlers {
         };
     
         // 3. Check if requester is authorized to check these permissions
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         let is_authorized = if is_owner {
             true
         } else {
@@ -185,7 +185,7 @@ pub mod permissions_handlers {
         };
     
         // 3. Check authorization
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         
         let resource_id = match parse_directory_resource_id(&request_body.filters.resource_id.to_string()) {
             Ok(id) => id,
@@ -381,7 +381,7 @@ pub mod permissions_handlers {
         }
     
         // 6. Check authorization
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         
         let mut allowed_permission_types = if is_owner {
             // Owner can grant any permission
@@ -538,7 +538,7 @@ pub mod permissions_handlers {
 
     
         // 6. Check authorization
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         
         let mut allowed_permission_types = if is_owner {
             // Owner can grant any permission
@@ -672,7 +672,7 @@ pub mod permissions_handlers {
         };
     
         // 4. Check authorization
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         let is_granter = permission.granted_by == requester_api_key.user_id;
         
         // Check manage permissions on the resource and all its parents
@@ -906,7 +906,7 @@ pub mod permissions_handlers {
             permissions.borrow().get(&permission_id).cloned()
         });
 
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         // 4. First check table-level permission
         if !check_permissions_table_access(&requester_api_key.user_id, SystemPermissionType::View, is_owner) {
             return create_auth_error_response();
@@ -915,7 +915,7 @@ pub mod permissions_handlers {
         // 4. Verify access rights
         match &permission {
             Some(p) => {
-                let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+                let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
                 
                 if !can_user_access_system_permission(&requester_api_key.user_id, p, is_owner) {
                     return create_auth_error_response();
@@ -959,7 +959,7 @@ pub mod permissions_handlers {
         };
     
         // 3. Check authorization
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         
         // Check table-level permissions if not owner
         if !is_owner {
@@ -1269,7 +1269,7 @@ pub mod permissions_handlers {
         };
     
         // 5. Check authorization
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         
     
         let current_time = ic_cdk::api::time() / 1_000_000; // Convert from ns to ms
@@ -1392,7 +1392,7 @@ pub mod permissions_handlers {
         }
     
         // 5. Check authorization
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         
     
         let current_time = ic_cdk::api::time() / 1_000_000; // Convert from ns to ms
@@ -1515,7 +1515,7 @@ pub mod permissions_handlers {
         let old_internal_id = permission.id.clone().to_string();
     
         // 4. Check authorization
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         let is_granter = permission.granted_by == requester_api_key.user_id;
         let has_table_permission = check_permissions_table_access(&requester_api_key.user_id, SystemPermissionType::Delete, is_owner);
     
@@ -1664,7 +1664,7 @@ pub mod permissions_handlers {
         };
     
         // 5. Check if requester is authorized to check these permissions
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         let is_authorized = if is_owner {
             true
         } else {

--- a/src/canisters-official-backend/src/rest/permissions/types.rs
+++ b/src/canisters-official-backend/src/rest/permissions/types.rs
@@ -47,7 +47,7 @@ impl SystemPermissionFE {
     pub fn redacted(&self, user_id: &UserID) -> Self {
         let mut redacted = self.clone();
 
-        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id.clone() == owner_id.borrow().get().clone());
         let has_edit_permissions = redacted.permission_previews.contains(&SystemPermissionType::Edit);
 
         // Most sensitive
@@ -105,7 +105,7 @@ impl DirectoryPermissionFE {
     pub fn redacted(&self, user_id: &UserID) -> Self {
         let mut redacted = self.clone();
 
-        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| *user_id == owner_id.borrow().get().clone());
         let has_edit_permissions = redacted.permission_previews.contains(&SystemPermissionType::Edit);
 
         // Most sensitive

--- a/src/canisters-official-backend/src/rest/types.rs
+++ b/src/canisters-official-backend/src/rest/types.rs
@@ -95,7 +95,7 @@ pub fn validate_unclaimed_uuid(id: &str) -> Result<(), ValidationError> {
     debug_log!("UUID_CLAIMED: {:?}", UUID_CLAIMED);
 
     // check that this id isnt already claimed
-    if UUID_CLAIMED.with(|claimed| claimed.borrow().contains_key(id)) {
+    if UUID_CLAIMED.with(|claimed| claimed.borrow().contains_key(&id.to_string())) {
         return Err(ValidationError {
             field: "id is not unique".to_string(),
             message: format!("{} is already claimed", id),

--- a/src/canisters-official-backend/src/rest/webhooks/handler.rs
+++ b/src/canisters-official-backend/src/rest/webhooks/handler.rs
@@ -8,7 +8,7 @@ pub mod webhooks_handlers {
         core::{
             api::{permissions::system::check_system_permissions, replay::diff::{snapshot_poststate, snapshot_prestate}, uuid::{generate_uuidv4, mark_claimed_uuid}},
             state::{drives::{state::state::{update_external_id_mapping, OWNER_ID}, types::{ExternalID, ExternalPayload}}, permissions::types::{PermissionGranteeID, SystemPermissionType, SystemRecordIDEnum, SystemResourceID, SystemTableEnum}, webhooks::{
-                state::state::{WEBHOOKS_BY_ALT_INDEX_HASHTABLE, WEBHOOKS_BY_ID_HASHTABLE, WEBHOOKS_BY_TIME_LIST}, types::{Webhook, WebhookAltIndexID, WebhookEventLabel, WebhookID}
+                state::state::{WEBHOOKS_BY_ALT_INDEX_HASHTABLE, WEBHOOKS_BY_ID_HASHTABLE, WEBHOOKS_BY_TIME_LIST, WEBHOOKS_BY_TIME_MEMORY_ID}, types::{Webhook, WebhookAltIndexID, WebhookEventLabel, WebhookID, WebhookIDList}
             }}, types::IDPrefix
         },
         debug_log,
@@ -16,11 +16,12 @@ pub mod webhooks_handlers {
             auth::{authenticate_request, create_auth_error_response}, webhooks::types::{
                 CreateWebhookRequestBody, CreateWebhookResponse, DeleteWebhookRequest, DeleteWebhookResponse, DeletedWebhookData, ErrorResponse, GetWebhookResponse, ListWebhooksRequestBody, ListWebhooksResponse, ListWebhooksResponseData, SortDirection, UpdateWebhookRequestBody, UpdateWebhookResponse
             }
-        },
+        }, MEMORY_MANAGER,
     };
     use ic_http_certification::{HttpRequest, HttpResponse, StatusCode};
     use matchit::Params;
     use serde::Deserialize;
+    use ic_stable_structures::StableVec;
 
     pub async fn get_webhook_handler<'a, 'k, 'v>(request: &'a HttpRequest<'a>, params: &'a Params<'k, 'v>) -> HttpResponse<'static> {
         // Authenticate request
@@ -54,7 +55,7 @@ pub mod webhooks_handlers {
 
         // Get the webhook
         let webhook = WEBHOOKS_BY_ID_HASHTABLE.with(|store| {
-            store.borrow().get(&webhook_id).cloned()
+            store.borrow().get(&webhook_id).clone()
         });
 
 
@@ -140,11 +141,11 @@ pub mod webhooks_handlers {
     
         // Determine starting point based on cursor
         let start_index = if let Some(cursor_idx) = start_cursor {
-            cursor_idx.min(total_count - 1)
+            cursor_idx.min((total_count - 1) as usize)
         } else {
             match request_body.direction {
                 SortDirection::Asc => 0,
-                SortDirection::Desc => total_count - 1,
+                SortDirection::Desc => (total_count - 1) as usize,
             }
         };
     
@@ -163,7 +164,7 @@ pub mod webhooks_handlers {
                 // First pass: Count total accessible records (for accurate pagination info)
                 if !is_owner {
                     for webhook_id in time_index.iter() {
-                        if let Some(webhook) = id_store.get(webhook_id) {
+                        if let Some(webhook) = id_store.get(&webhook_id) {
                             // Check if user has permission to view this specific webhook
                             let resource_id = SystemResourceID::Record(
                                 SystemRecordIDEnum::Webhook(webhook.id.clone().to_string())
@@ -190,30 +191,32 @@ pub mod webhooks_handlers {
                     SortDirection::Desc => {
                         // Newest first
                         let mut current_idx = start_index;
-                        while filtered_webhooks.len() < request_body.page_size && current_idx < total_count {
-                            if let Some(webhook) = id_store.get(&time_index[current_idx]) {
+                        while filtered_webhooks.len() < request_body.page_size && current_idx < total_count as usize {
+                            if let Some(webhook_id) = time_index.get(current_idx as u64) {
+                                if let Some(webhook) = id_store.get(&webhook_id) {
                                 // Check text filter first (cheaper operation)
                                 let passes_filter = request_body.filters.is_empty() || 
                                                    webhook.event.to_string().contains(&request_body.filters);
                                 
                                 if passes_filter {
-                                    // Then check permissions for this specific webhook
-                                    let has_permission = if is_owner {
-                                        true // Owner can access everything
-                                    } else {
-                                        let resource_id = SystemResourceID::Record(
-                                            SystemRecordIDEnum::Webhook(webhook.id.clone().to_string())
-                                        );
+                                        // Then check permissions for this specific webhook
+                                        let has_permission = if is_owner {
+                                            true // Owner can access everything
+                                        } else {
+                                            let resource_id = SystemResourceID::Record(
+                                                SystemRecordIDEnum::Webhook(webhook.id.clone().to_string())
+                                            );
+                                            
+                                            check_system_permissions(
+                                                resource_id,
+                                                PermissionGranteeID::User(requester_api_key.user_id.clone())
+                                            ).contains(&SystemPermissionType::View)
+                                        };
                                         
-                                        check_system_permissions(
-                                            resource_id,
-                                            PermissionGranteeID::User(requester_api_key.user_id.clone())
-                                        ).contains(&SystemPermissionType::View)
-                                    };
-                                    
-                                    if has_permission || has_table_permission {
-                                        viewed_count += 1;
-                                        filtered_webhooks.push(webhook.clone());
+                                        if has_permission || has_table_permission {
+                                            viewed_count += 1;
+                                            filtered_webhooks.push(webhook.clone());
+                                        }
                                     }
                                 }
                             }
@@ -229,37 +232,39 @@ pub mod webhooks_handlers {
                     SortDirection::Asc => {
                         // Oldest first
                         let mut current_idx = start_index;
-                        while filtered_webhooks.len() < request_body.page_size && current_idx < total_count {
-                            if let Some(webhook) = id_store.get(&time_index[current_idx]) {
-                                // Check text filter first (cheaper operation)
-                                let passes_filter = request_body.filters.is_empty() || 
-                                                   webhook.event.to_string().contains(&request_body.filters);
-                                
-                                if passes_filter {
-                                    // Then check permissions for this specific webhook
-                                    let has_permission = if is_owner {
-                                        true // Owner can access everything
-                                    } else {
-                                        let resource_id = SystemResourceID::Record(
-                                            SystemRecordIDEnum::Webhook(webhook.id.clone().to_string())
-                                        );
-                                        
-                                        check_system_permissions(
-                                            resource_id,
-                                            PermissionGranteeID::User(requester_api_key.user_id.clone())
-                                        ).contains(&SystemPermissionType::View)
-                                    };
+                        while filtered_webhooks.len() < request_body.page_size && current_idx < total_count as usize {
+                            if let Some(webhook_id) = time_index.get(current_idx as u64) {
+                                if let Some(webhook) = id_store.get(&webhook_id) {
+                                    // Check text filter first (cheaper operation)
+                                    let passes_filter = request_body.filters.is_empty() || 
+                                                    webhook.event.to_string().contains(&request_body.filters);
                                     
-                                    if has_permission || has_table_permission {
-                                        viewed_count += 1;
-                                        filtered_webhooks.push(webhook.clone());
+                                    if passes_filter {
+                                        // Then check permissions for this specific webhook
+                                        let has_permission = if is_owner {
+                                            true // Owner can access everything
+                                        } else {
+                                            let resource_id = SystemResourceID::Record(
+                                                SystemRecordIDEnum::Webhook(webhook.id.clone().to_string())
+                                            );
+                                            
+                                            check_system_permissions(
+                                                resource_id,
+                                                PermissionGranteeID::User(requester_api_key.user_id.clone())
+                                            ).contains(&SystemPermissionType::View)
+                                        };
+                                        
+                                        if has_permission || has_table_permission {
+                                            viewed_count += 1;
+                                            filtered_webhooks.push(webhook.clone());
+                                        }
                                     }
                                 }
                             }
                             
                             current_idx += 1;
                             processed_count += 1;
-                            if current_idx >= total_count {
+                            if current_idx >= total_count as usize {
                                 break;
                             }
                         }
@@ -280,7 +285,7 @@ pub mod webhooks_handlers {
                     }
                 },
                 SortDirection::Asc => {
-                    if end_index < total_count - 1 {
+                    if end_index < total_count as usize - 1 {
                         Some((end_index + 1).to_string())
                     } else {
                         None
@@ -297,7 +302,7 @@ pub mod webhooks_handlers {
                 webhook.cast_fe(&requester_api_key.user_id)
             }).collect(),
             page_size: filtered_webhooks.len(),
-            total: total_accessible_count, // Use the count of accessible records
+            total: total_accessible_count as usize, // Use the count of accessible records
             direction: request_body.direction,
             cursor: next_cursor,
         };
@@ -372,13 +377,16 @@ pub mod webhooks_handlers {
         // Update state tables – now storing a Vec<WebhookID> without removing others
         WEBHOOKS_BY_ALT_INDEX_HASHTABLE.with(|store| {
             let mut store = store.borrow_mut();
-            store.entry(alt_index.clone())
-                .and_modify(|vec_ids| {
-                    if !vec_ids.contains(&webhook_id) {
-                        vec_ids.push(webhook_id.clone());
-                    }
-                })
-                .or_insert_with(|| vec![webhook_id.clone()]);
+            
+            if let Some(mut webhook_list) = store.get(&alt_index) {
+                if !webhook_list.contains(&webhook_id) {
+                    webhook_list.add(webhook_id.clone());
+                }
+                store.insert(alt_index.clone(), webhook_list);
+            } else {
+                let new_list = WebhookIDList::with_webhook(webhook_id.clone());
+                store.insert(alt_index.clone(), new_list);
+            }
         });
 
         WEBHOOKS_BY_ID_HASHTABLE.with(|store| {
@@ -386,7 +394,7 @@ pub mod webhooks_handlers {
         });
 
         WEBHOOKS_BY_TIME_LIST.with(|store| {
-            store.borrow_mut().push(webhook_id.clone());
+            store.borrow_mut().push(&webhook_id.clone());
         });
 
         mark_claimed_uuid(&webhook_id.clone().to_string());
@@ -430,7 +438,7 @@ pub mod webhooks_handlers {
         let webhook_id = WebhookID(update_req.id);
         
         // Get existing webhook
-        let mut webhook = match WEBHOOKS_BY_ID_HASHTABLE.with(|store| store.borrow().get(&webhook_id).cloned()) {
+        let mut webhook = match WEBHOOKS_BY_ID_HASHTABLE.with(|store| store.borrow().get(&webhook_id).clone()) {
             Some(hook) => hook,
             None => return create_response(
                 StatusCode::NOT_FOUND,
@@ -557,7 +565,7 @@ pub mod webhooks_handlers {
         let prestate = snapshot_prestate();
 
         // Get webhook to delete
-        let webhook = match WEBHOOKS_BY_ID_HASHTABLE.with(|store| store.borrow().get(&webhook_id).cloned()) {
+        let webhook = match WEBHOOKS_BY_ID_HASHTABLE.with(|store| store.borrow().get(&webhook_id).clone()) {
             Some(hook) => hook,
             None => return create_response(
                 StatusCode::NOT_FOUND,
@@ -569,11 +577,15 @@ pub mod webhooks_handlers {
 
         // Remove from all hashtables
         WEBHOOKS_BY_ALT_INDEX_HASHTABLE.with(|store| {
-            let mut map = store.borrow_mut();
-            if let Some(ids) = map.get_mut(&webhook.alt_index) {
-                ids.retain(|id| id != &webhook_id);
-                if ids.is_empty() {
-                    map.remove(&webhook.alt_index);
+            let mut store = store.borrow_mut();
+            
+            if let Some(mut webhook_list) = store.get(&webhook.alt_index) {
+                webhook_list.remove(&webhook_id); // Using the method you already defined
+                
+                if webhook_list.is_empty() {
+                    store.remove(&webhook.alt_index);
+                } else {
+                    store.insert(webhook.alt_index.clone(), webhook_list);
                 }
             }
         });
@@ -583,7 +595,33 @@ pub mod webhooks_handlers {
         });
 
         WEBHOOKS_BY_TIME_LIST.with(|store| {
-            store.borrow_mut().retain(|id| id != &webhook_id);
+            let mut time_list = store.borrow_mut();
+            let length = time_list.len();
+            
+            // Create a new vector with the IDs to keep
+            let mut new_indices = Vec::new();
+            
+            // Find indices of entries to keep
+            for i in 0..length {
+                if let Some(id) = time_list.get(i) {
+                    if id != webhook_id {
+                        new_indices.push((i, id.clone()));
+                    }
+                }
+            }
+            
+            // Create a new StableVec
+            let mut new_time_list = StableVec::init(
+                MEMORY_MANAGER.with(|m| m.borrow().get(WEBHOOKS_BY_TIME_MEMORY_ID))
+            ).expect("Failed to initialize new WEBHOOKS_BY_TIME_LIST");
+            
+            // Add the IDs to the new list
+            for (_, id) in new_indices {
+                new_time_list.push(&id);
+            }
+            
+            // Replace the old list with the new one
+            *time_list = new_time_list;
         });
 
         update_external_id_mapping(old_external_id, None, old_internal_id);

--- a/src/canisters-official-backend/src/rest/webhooks/handler.rs
+++ b/src/canisters-official-backend/src/rest/webhooks/handler.rs
@@ -35,7 +35,7 @@ pub mod webhooks_handlers {
 
 
         // Only owner can access webhooks
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         if !is_owner {
             let resource_id = SystemResourceID::Record(SystemRecordIDEnum::Webhook(webhook_id.to_string()));
             let record_permissions = check_system_permissions(
@@ -78,7 +78,7 @@ pub mod webhooks_handlers {
         };
     
         // Check if user is owner (for optimization)
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         
         let has_table_permission = if !is_owner {
             let resource_id = SystemResourceID::Table(SystemTableEnum::Webhooks);
@@ -316,7 +316,7 @@ pub mod webhooks_handlers {
         };
 
         // Only owner can manage webhooks
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
 
         // Parse request body
         let body: &[u8] = request.body();
@@ -414,7 +414,7 @@ pub mod webhooks_handlers {
         };
 
         // Only owner can manage webhooks
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
 
         // Parse request body
         let body: &[u8] = request.body();
@@ -537,7 +537,7 @@ pub mod webhooks_handlers {
         let webhook_id = WebhookID(delete_request.id.clone());
 
         // Only owner can manage webhooks
-        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| requester_api_key.user_id == owner_id.borrow().get().clone());
         if !is_owner {
             let resource_id = SystemResourceID::Record(SystemRecordIDEnum::Webhook(webhook_id.to_string()));
             let record_permissions = check_system_permissions(

--- a/src/canisters-official-backend/src/rest/webhooks/types.rs
+++ b/src/canisters-official-backend/src/rest/webhooks/types.rs
@@ -32,7 +32,7 @@ impl WebhookFE {
     pub fn redacted(&self, user_id: &UserID) -> Self {
         let mut redacted = self.clone();
 
-        let is_owner = OWNER_ID.with(|owner_id| *user_id == *owner_id.borrow());
+        let is_owner = OWNER_ID.with(|owner_id| user_id.clone() == owner_id.borrow().get().clone());
         let has_edit_permissions = redacted.permission_previews.contains(&SystemPermissionType::Edit);
 
         // Most sensitive

--- a/src/canisters-official-backend/src/rest/webhooks/types.rs
+++ b/src/canisters-official-backend/src/rest/webhooks/types.rs
@@ -257,7 +257,7 @@ impl UpdateWebhookRequestBody {
             
             // Check if this is an inbox webhook by finding it
             let webhook_id = WebhookID(self.id.clone());
-            let webhook = WEBHOOKS_BY_ID_HASHTABLE.with(|store| store.borrow().get(&webhook_id).cloned());
+            let webhook = WEBHOOKS_BY_ID_HASHTABLE.with(|store| store.borrow().get(&webhook_id).clone());
             
             if let Some(webhook) = webhook {
                 if webhook.event == WebhookEventLabel::OrganizationInboxNewNotif && !filters.is_empty() {

--- a/src/canisters-official-backend/src/rest/webhooks/types.rs
+++ b/src/canisters-official-backend/src/rest/webhooks/types.rs
@@ -1,5 +1,6 @@
 // src/rest/webhooks/types.rs
 
+use candid::CandidType;
 use serde::{Deserialize, Serialize};
 use crate::core::api::uuid::ShareTrackHash;
 use crate::core::state::directory::types::{FileRecord, FolderRecord, ShareTrackID, ShareTrackResourceID};
@@ -20,7 +21,7 @@ use crate::rest::types::{validate_description, validate_external_id, validate_ex
 
 
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct WebhookFE {
     #[serde(flatten)] 
     pub webhook: Webhook,
@@ -56,7 +57,7 @@ impl WebhookFE {
 
 
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CandidType)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SortDirection {
     Asc,
@@ -71,7 +72,7 @@ impl Default for SortDirection {
 
 
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, CandidType)]
 pub struct ListWebhooksRequestBody {
     #[serde(default)]
     pub filters: String,
@@ -114,7 +115,7 @@ impl ListWebhooksRequestBody {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, CandidType)]
 pub struct ListWebhooksResponseData {
     pub items: Vec<WebhookFE>,
     pub page_size: usize,
@@ -124,7 +125,7 @@ pub struct ListWebhooksResponseData {
 }
 
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, CandidType)]
 #[serde(deny_unknown_fields)]
 pub struct CreateWebhookRequestBody {
     pub id: Option<ClientSuggestedUUID>,
@@ -215,7 +216,7 @@ impl CreateWebhookRequestBody {
 }
 
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, CandidType)]
 pub struct UpdateWebhookRequestBody {
     pub id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -308,7 +309,7 @@ impl UpdateWebhookRequestBody {
 }
 
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, CandidType)]
 pub struct DeleteWebhookRequest {
     pub id: String,
 }
@@ -321,7 +322,7 @@ impl DeleteWebhookRequest {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, CandidType)]
 pub struct DeletedWebhookData {
     pub id: WebhookID,
     pub deleted: bool
@@ -384,13 +385,13 @@ pub enum WebhookResourceData {
     OrgInboxNewNotif(InboxOrgRequestBody),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct GroupInviteWebhookData {
     pub group: Option<Group>,
     pub group_invite: Option<GroupInvite>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct LabelWebhookData {
     pub resource_id: LabelResourceID,
     pub label_id: LabelID,
@@ -398,7 +399,7 @@ pub struct LabelWebhookData {
     pub add: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct DriveStateDiffWebhookData {
     pub data: StateDiffRecord
 }
@@ -428,12 +429,12 @@ pub enum DirectoryWebhookData {
     ShareTracking(ShareTrackingWebhookData),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct FileWebhookData {
     pub file: Option<FileRecord>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, CandidType)]
 pub struct FolderWebhookData {
     pub folder: Option<FolderRecord>,
 }


### PR DESCRIPTION
Massive PR that refactors all `thread_local!` state to use `ic_stable_structures` to survive canister upgrades without risk of data loss. I wish this was done earlier near start so that we could have cleaner patterns, as its currently quite verbose. However its still manageable with or without AI. Lightly tested working without gotchas, but further testing needed.
